### PR TITLE
Added a cross-compiled, 32bit, PowerPC Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: cpp
 dist: xenial
 sudo: required
+services:
+  - docker
 branches:
   only:
     - master
@@ -37,6 +39,15 @@ install:
 # Build matrix
 matrix:
   include:
+    - env: VERSION=5 ARCH=powerpc-linux
+      os: linux
+      compiler: gcc
+      script:
+        - docker build -f Dockerfile.build -t builder .
+        - docker run --name="build_results" builder
+        - docker cp build_results:/root/libdart/build/test/unit_tests .
+        - docker build -f Dockerfile.harness -t test_harness .
+        - sudo docker run --privileged test_harness
     - env: VERSION=3.8
       os: linux
       compiler: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ option(no_cxx17 "Disabling c++17" OFF)
 
 # Define an option for our tests.
 option(test "Building tests..." ON)
+option(32bit "Building for a 32-bit target..." OFF)
+option(static_test "Statically linking tests..." OFF)
 option(extended_test "Building extended tests..." OFF)
 
 # Define global compiler flags.

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,16 @@
+# Pull in our big-endian cross-compiler
+FROM cfretz244/libdart_ci:bebuilder
+
+# Set ourselves to use a login shell
+# so we use our big-endian toolchain
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Copy the code in.
+COPY . /root/libdart
+
+# Compile it.
+CMD cd /root/libdart                                            \
+  && mkdir build                                                \
+  && cd build                                                   \
+  && cmake .. -D32bit=ON -Dstatic_test=ON -Dextended_test=ON    \
+  && make

--- a/Dockerfile.harness
+++ b/Dockerfile.harness
@@ -1,0 +1,8 @@
+# Pull in our test harness emulator
+FROM cfretz244/libdart_ci:test_harness
+
+# Copy the unit tests into the root directory
+COPY unit_tests /root
+
+# Run our bootstrap script
+CMD /root/provision.sh

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,12 @@ endif ()
 if (extended_test)
   target_compile_options(unit_tests PUBLIC "-DDART_EXTENDED_TESTS")
 endif ()
+if (32bit)
+  target_link_libraries(unit_tests atomic)
+endif ()
+if (static_test)
+  target_link_libraries(unit_tests "-static-libstdc++")
+endif ()
 target_compile_options(unit_tests PUBLIC "-g")
 
 # Setup targest for JSON tests.


### PR DESCRIPTION
Added for the purpose of validating the endian independence of Dart's network buffer.
Proved to be surprisingly challenging.