### PR TITLE
(WIP) CMake files cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,85 @@
-# Have cmake distinguish between clang and apple clang.
-cmake_policy(SET CMP0025 NEW)
-
-# Name the project.
-project(libdart)
 cmake_minimum_required(VERSION 3.1.0)
-include(CheckIncludeFileCXX)
+project(libdart)
 
-# Check which dependencies are installed.
-find_path(libgsl gsl/gsl)
-find_library(libyaml yaml)
-find_path(librj rapidjson/reader.h)
-if (NOT librj)
-  CHECK_INCLUDE_FILE_CXX("rapidjson/reader.h" librj)
-endif ()
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
-# GSL is our only hard dependency, error out if it's not here.
-if (NOT libgsl)
-  message(FATAL_ERROR "Microsoft GSL must be installed")
-endif ()
-include_directories(${libgsl})
+include(CMakeDependentOption)
+include(CTest)
 
-# Decide if we can build the YAML features or not.
-if (libyaml AND librj)
+include(FetchDependency) # Local
+
+fetch_option(LIBDART_FETCH_MicrosoftGSL "Fetch Microsoft GSL if not installed")
+fetch_option(LIBDART_FETCH_RapidJSON "Fetch RapidJSON if not installed")
+fetch_option(LIBDART_FETCH_libyaml "Fetch libyaml if not installed")
+
+set(json-fetch-url "https://github.com/Tencent/rapidjson/archive/v1.1.0.zip")
+set(yaml-fetch-url "https://github.com/yaml/libyaml/archive/0.2.2.zip")
+set(gsl-fetch-url "https://github.com/microsoft/GSL/archive/v2.0.0.zip")
+
+find_package(MicrosoftGSL)
+find_package(RapidJSON MODULE)
+find_package(Yaml)
+
+option(BUILD_BENCHMARKS "Build project benchmarks")
+
+# Explicitly disable C++17 for whatever reason.
+#option(no_cxx17 "Disabling c++17" OFF)
+
+# Define an option for our tests.
+option(32bit "Building for a 32-bit target..." OFF)
+option(static_test "Statically linking tests..." OFF)
+option(extended_test "Building extended tests..." OFF)
+option(force_build "Proceeding with unsupported compilation...")
+
+if (NOT MicrosoftGSL_FOUND)
+  if (LIBDART_FETCH_MicrosoftGSL)
+    libdart_fetch_dependency(MicrosoftGSL URL ${gsl-fetch-url})
+    add_subdirectory(${MicrosoftGSL_SOURCE_DIR} ${MicrosoftGSL_BINARY_DIR})
+    add_library(MicrosoftGSL ALIAS GSL)
+  else()
+    message(FATAL_ERROR "Microsoft GSL must be installed")
+  endif()
+endif()
+
+if (NOT Yaml_FOUND AND LIBDART_FETCH_libyaml)
+  libdart_fetch_dependency(Yaml URL ${yaml-fetch-url})
+  set(BUILD_TESTING OFF)
+  add_subdirectory(${Yaml_SOURCE_DIR} ${Yaml_BINARY_DIR} EXCLUDE_FROM_ALL)
+  set(BUILD_TESTING ON)
+  add_library(Yaml::Yaml ALIAS yaml)
+endif()
+
+if (NOT RapidJSON_FOUND AND LIBDART_FETCH_RapidJSON)
+  libdart_fetch_dependency(RapidJSON URL ${json-fetch-url})
+  add_subdirectory(${RapidJSON_SOURCE_DIR} ${RapidJSON_BINARY_DIR} EXCLUDE_FROM_ALL)
+  add_library(RapidJSON INTERFACE)
+  add_library(RapidJSON::RapidJSON ALIAS RapidJSON)
+  target_include_directories(RapidJSON INTERFACE ${RapidJSON_SOURCE_DIR}/include)
+endif()
+
+if (TARGET Yaml::Yaml AND TARGET RapidJSON::RapidJSON)
   set(can_build_yaml ON)
-endif ()
+endif()
+
+add_library(dart INTERFACE)
+target_include_directories(dart INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_compile_definitions(dart INTERFACE
+  $<$<TARGET_EXISTS:RapidJSON::RapidJSON>:DART_HAS_RAPIDJSON>
+  $<$<TARGET_EXISTS:Yaml::Yaml>:DART_HAS_YAML>)
+
+target_compile_options(dart INTERFACE
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wno-implicit-fallthrough -Wno-unused-local-typedefs>)
+
+target_compile_features(dart INTERFACE cxx_std_17)
+
+target_link_libraries(dart INTERFACE
+  MicrosoftGSL
+  $<TARGET_NAME_IF_EXISTS:Yaml::Yaml>
+  $<TARGET_NAME_IF_EXISTS:RapidJSON::RapidJSON>)
 
 # Figure out what toolchain we're using.
-option(force_build "Proceeding with unsupported compilation...")
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "[cC][lL][aA][nN][gG]")
   set(using_clang ON)
   if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
@@ -48,40 +101,13 @@ elseif (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.9 AND using_clang AND using
   try_compile(using_cxx17 ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test/macos_feature_check.cc)
 endif ()
 
-# Explicitly disable C++17 for whatever reason.
-option(no_cxx17 "Disabling c++17" OFF)
-
-# Define an option for our tests.
-option(test "Building tests..." ON)
-option(32bit "Building for a 32-bit target..." OFF)
-option(static_test "Statically linking tests..." OFF)
-option(extended_test "Building extended tests..." OFF)
-
 # Define global compiler flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-implicit-fallthrough -Wno-unused-local-typedefs")
-if (using_cxx17 AND NOT no_cxx17)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-else ()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-endif ()
-if (librj)
-  add_definitions("-DDART_HAS_RAPIDJSON")
-endif ()
-if (can_build_yaml)
-  add_definitions("-DDART_HAS_YAML")
-endif ()
-
-# Define our source files.
-include_directories(include)
-
-# Conditionally setup our tests.
-if (test)
-  enable_testing()
+if (BUILD_TESTING)
   add_subdirectory(test)
 endif ()
 
 # Conditionally setup our benchmarks.
-if (benchmark)
+if (BUILD_BENCHMARKS)
   add_subdirectory(benchmark)
 endif ()
 

--- a/cmake/FetchDependency.cmake
+++ b/cmake/FetchDependency.cmake
@@ -1,0 +1,21 @@
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.11)
+  include(FetchContent)
+endif()
+
+include(CMakeDependentOption)
+
+function (fetch_option name description)
+  cmake_dependent_option(${name} ${description} ON
+    "CMAKE_VERSION VERSION_GREATER_EQUAL 3.11" OFF)
+endfunction()
+
+function (libdart_fetch_dependency name)
+  FetchContent_Declare(${name} ${ARGN})
+  FetchContent_GetProperties(${name})
+  if (NOT ${name}_POPULATED)
+    FetchContent_Populate(${name})
+    string(TOLOWER ${name} lcname)
+    set(${name}_SOURCE_DIR ${${lcname}_SOURCE_DIR} PARENT_SCOPE)
+    set(${name}_BINARY_DIR ${${lcname}_BINARY_DIR} PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/FindMicrosoftGSL.cmake
+++ b/cmake/FindMicrosoftGSL.cmake
@@ -1,0 +1,13 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(MicrosoftGSL_INCLUDE_DIR gsl/gsl)
+
+find_package_handle_standard_args(MicrosoftGSL
+  REQUIRED_VARS MicrosoftGSL_INCLUDE_DIR)
+
+if (MicrosoftGSL_FOUND)
+  add_library(MicrosoftGSL INTERFACE IMPORTED)
+  target_include_directories(MicrosoftGSL INTERFACE ${MicrosoftGSL_INCLUDE_DIR})
+endif()
+
+

--- a/cmake/FindYaml.cmake
+++ b/cmake/FindYaml.cmake
@@ -1,0 +1,11 @@
+include(FindPackageHandleStandardArgs)
+
+find_library(YAML_LIBRARY yaml)
+
+find_package_handle_standard_args(Yaml REQUIRED_VARS YAML_LIBRARY)
+
+if (Yaml_FOUND)
+  add_library(Yaml::Yaml IMPORTED)
+  set_target_properties(Yaml::Yaml PROPERTIES
+    IMPORTED_LOCATION ${YAML_LIBRARY})
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,48 +1,73 @@
 # Define a catch library so we only have to build it once.
+find_package(Catch2 QUIET)
+set(catch-fetch-url "https://github.com/catchorg/Catch2/archive/v2.7.2.zip")
+
+if (NOT Catch2_FOUND)
+  libdart_fetch_dependency(Catch2 URL ${catch-fetch-url})
+  add_subdirectory(${Catch2_SOURCE_DIR} ${Catch2_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
 add_library(catch OBJECT catch_driver.cc)
+target_compile_features(catch PUBLIC cxx_std_17)
+target_link_libraries(catch PUBLIC Catch2::Catch2)
 
 # Setup targets for our unit tests.
-add_executable(unit_tests type_unit_tests.cc obj_unit_tests.cc arr_unit_tests.cc str_unit_tests.cc int_unit_tests.cc dcm_unit_tests.cc bool_unit_tests.cc null_unit_tests.cc iteration_unit_tests.cc ptr_unit_tests.cc misc_unit_tests.cc optional_unit_tests.cc string_view_unit_tests.cc $<TARGET_OBJECTS:catch>)
-if (can_build_yaml)
-  target_link_libraries(unit_tests ${libyaml})
-endif ()
-if (extended_test)
-  target_compile_options(unit_tests PUBLIC "-DDART_EXTENDED_TESTS")
-endif ()
-if (32bit)
-  target_link_libraries(unit_tests atomic)
-endif ()
-if (static_test)
-  target_link_libraries(unit_tests "-static-libstdc++")
-endif ()
-target_compile_options(unit_tests PUBLIC "-g")
+add_executable(unit_tests)
 
-# Setup targest for JSON tests.
-if (librj)
+target_compile_features(unit_tests PUBLIC cxx_std_17)
+
+target_sources(unit_tests
+  PRIVATE
+    type_unit_tests.cc
+    obj_unit_tests.cc
+    arr_unit_tests.cc
+    str_unit_tests.cc
+    int_unit_tests.cc
+    dcm_unit_tests.cc
+    bool_unit_tests.cc
+    null_unit_tests.cc
+    iteration_unit_tests.cc
+    ptr_unit_tests.cc
+    misc_unit_tests.cc
+    optional_unit_tests.cc
+    string_view_unit_tests.cc
+    $<TARGET_OBJECTS:catch>)
+
+target_compile_definitions(unit_tests PUBLIC
+  $<$<BOOL:${extended_test}>:DART_EXTENDED_TESTS>)
+
+target_compile_options(unit_tests
+  PRIVATE
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-g>
+    $<$<CXX_COMPILER_ID:GCC>:-static-libstdc++>)
+
+target_link_libraries(unit_tests PRIVATE dart)
+
+if (TARGET RapidJSON::RapidJSON)
   add_executable(json_test json_test.cc $<TARGET_OBJECTS:catch>)
-  target_compile_options(json_test PUBLIC "-g")
-  if (extended_test)
-    target_compile_options(json_test PUBLIC "-DDART_EXTENDED_TESTS")
-  endif ()
-endif ()
+  target_compile_features(json_test PRIVATE cxx_std_17)
+  target_compile_options(json_test PRIVATE $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-g>)
+  target_compile_definitions(json_test PRIVATE
+    $<$<BOOL:${extended_test}>:DART_EXTENDED_TESTS>)
+  target_link_libraries(json_test PRIVATE dart)
+endif()
 
-# Same for yaml.
-if (can_build_yaml)
+if (TARGET Yaml::Yaml AND TARGET RapidJSON::RapidJSON)
   add_executable(yaml_test yaml_test.cc $<TARGET_OBJECTS:catch>)
-  target_link_libraries(yaml_test ${libyaml})
-  target_compile_options(yaml_test PUBLIC "-g")
-  if (extended_test)
-    target_compile_options(yaml_test PUBLIC "-DDART_EXTENDED_TESTS")
-  endif ()
-endif ()
+  target_compile_features(yaml_test PRIVATE cxx_std_17)
+  target_compile_options(yaml_test PRIVATE $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-g>)
+  target_compile_definitions(yaml_test PRIVATE
+    $<$<BOOL:${extended_test}>:DART_EXTENDED_TESTS>)
+  target_link_libraries(yaml_test PRIVATE dart)
+endif()
 
-# Create a cmake test to call through to our test binary.
 add_test(NAME dart_unit_tests COMMAND unit_tests)
-if (librj)
+if (TARGET RapidJSON::RapidJSON)
   add_test(NAME dart_json_tests COMMAND json_test)
-endif ()
-if (can_build_yaml)
+endif()
+if (TARGET Yaml::Yaml AND TARGET RapidJSON::RapidJSON)
   add_test(NAME dart_yaml_tests COMMAND yaml_test)
 endif ()
-file(COPY ${CMAKE_CURRENT_SOURCE_DIRECTORY}test.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY ${CMAKE_CURRENT_SOURCE_DIRECTORY}test.yml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+configure_file(test.json test.json COPYONLY)
+configure_file(test.yml test.yml COPYONLY)

--- a/test/catch_driver.cc
+++ b/test/catch_driver.cc
@@ -2,4 +2,4 @@
 
 #define CATCH_CONFIG_MAIN
 
-#include <extern/catch.h>
+#include <catch2/catch.hpp>


### PR DESCRIPTION
Will now download dependencies if possible.
Creates an interface library for easier modification of flags and such
Uses generator expressions to make adding MSVC support more possible.

Might make more sense to upgrade the minimum CMake version to something
more modern. CMake 3.1 came out in approximately 2015.

We don't try to "find" RapidJSON as it ends up force overwriting several
install variables if not set and this ends up causing issues.

Some more work is needed to make sure the correct flags are set for
AppleClang and friends.

That said, this currently compiles under Linux with gcc just fine so it shouldn't disrupt existing workflows too much.