### PR TITLE
Adding dart::packet::view family of types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,8 +194,8 @@ script:
   - cd build
   - cmake .. -Dextended_test=ON -Dbenchmark=ON -Dbuild_abi=ON
   - make VERBOSE=1
-  - ctest
+  - ctest --output-on-failure
   - make clean
   - cmake .. -Duse_sajson=ON -Dextended_test=OFF
   - make VERBOSE=1
-  - ctest
+  - ctest --output-on-failure

--- a/include/dart.h
+++ b/include/dart.h
@@ -445,7 +445,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_object const& other) const noexcept;
+      template <class OtherObject>
+      bool operator ==(basic_object<OtherObject> const& other) const noexcept;
 
       /**
        *  @brief
@@ -461,7 +462,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_object const& other) const noexcept;
+      template <class OtherObject>
+      bool operator !=(basic_object<OtherObject> const& other) const noexcept;
 
       /**
        *  @brief
@@ -1769,7 +1771,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_array const& other) const noexcept;
+      template <class OtherArray>
+      bool operator ==(basic_array<OtherArray> const& other) const noexcept;
 
       /**
        *  @brief
@@ -1785,7 +1788,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_array const& other) const noexcept;
+      template <class OtherArray>
+      bool operator !=(basic_array<OtherArray> const& other) const noexcept;
 
       /**
        *  @brief
@@ -2834,7 +2838,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_string const& other) const noexcept;
+      template <class OtherString>
+      bool operator ==(basic_string<OtherString> const& other) const noexcept;
 
       /**
        *  @brief
@@ -2850,7 +2855,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_string const& other) const noexcept;
+      template <class OtherString>
+      bool operator !=(basic_string<OtherString> const& other) const noexcept;
 
       /**
        *  @brief
@@ -3308,7 +3314,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_number const& other) const noexcept;
+      template <class OtherNumber>
+      bool operator ==(basic_number<OtherNumber> const& other) const noexcept;
 
       /**
        *  @brief
@@ -3324,7 +3331,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_number const& other) const noexcept;
+      template <class OtherNumber>
+      bool operator !=(basic_number<OtherNumber> const& other) const noexcept;
 
       /**
        *  @brief
@@ -3757,7 +3765,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_flag const& other) const noexcept;
+      template <class OtherBoolean>
+      bool operator ==(basic_flag<OtherBoolean> const& other) const noexcept;
 
       /**
        *  @brief
@@ -3773,7 +3782,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_flag const& other) const noexcept;
+      template <class OtherBoolean>
+      bool operator !=(basic_flag<OtherBoolean> const& other) const noexcept;
 
       /**
        *  @brief
@@ -4133,7 +4143,8 @@ namespace dart {
        *  For strongly typed null packets, always returns true as all
        *  null instances are considered equal to each other.
        */
-      constexpr bool operator ==(basic_null const& other) const noexcept;
+      template <class OtherNull>
+      constexpr bool operator ==(basic_null<OtherNull> const& other) const noexcept;
 
       /**
        *  @brief
@@ -4143,7 +4154,8 @@ namespace dart {
        *  For strongly typed null packets, always returns true as all
        *  null instances are considered equal to each other.
        */
-      constexpr bool operator !=(basic_null const& other) const noexcept;
+      template <class OtherNull>
+      constexpr bool operator !=(basic_null<OtherNull> const& other) const noexcept;
 
       /**
        *  @brief
@@ -4416,11 +4428,11 @@ namespace dart {
 
           /*----- Private Lifecycle Functions -----*/
 
-          iterator(detail::dn_iterator<RefCount> it) : impl(std::move(it)) {}
+          iterator(detail::dynamic_iterator<RefCount> it) : impl(std::move(it)) {}
 
           /*----- Private Members -----*/
 
-          shim::optional<detail::dn_iterator<RefCount>> impl;
+          shim::optional<detail::dynamic_iterator<RefCount>> impl;
 
           /*----- Friends -----*/
 
@@ -4434,6 +4446,8 @@ namespace dart {
       using number = basic_number<basic_heap>;
       using flag = basic_flag<basic_heap>;
       using null = basic_null<basic_heap>;
+
+      using view = basic_heap<view_ptr_context<RefCount>::template view_ptr>;
 
       using size_type = size_t;
       using reverse_iterator = std::reverse_iterator<iterator>;
@@ -4563,7 +4577,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_heap const& other) const noexcept;
+      template <template <class> class OtherRC>
+      bool operator ==(basic_heap<OtherRC> const& other) const noexcept;
 
       /**
        *  @brief
@@ -4577,7 +4592,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_heap const& other) const noexcept;
+      template <template <class> class OtherRC>
+      bool operator !=(basic_heap<OtherRC> const& other) const noexcept;
 
       /**
        *  @brief
@@ -4610,6 +4626,14 @@ namespace dart {
        *  Returns true in all other situations.
        */
       explicit operator bool() const noexcept;
+
+      /**
+       *  @brief
+       *  Operator allows for converting the current heap instance into a
+       *  non-owning, read-only, view
+       */
+      operator view() const& noexcept;
+      operator view() && = delete;
 
       /**
        *  @brief
@@ -4667,6 +4691,8 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           sizeof...(Args) % 2 == 0
         >
       >
@@ -4682,6 +4708,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_object(gsl::span<basic_heap const> pairs);
 
       /**
@@ -4694,6 +4725,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_object(gsl::span<basic_buffer<RefCount> const> pairs);
 
       /**
@@ -4706,6 +4742,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_object(gsl::span<basic_packet<RefCount> const> pairs);
 
       /**
@@ -4715,11 +4756,15 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
-          (sizeof...(Args) > 1)
-          ||
-          !meta::is_span<
-            meta::first_type_t<std::decay_t<Args>...>
-          >::value
+          refcount::is_owner<RefCount>::value
+          &&
+          (
+            (sizeof...(Args) > 1)
+            ||
+            !meta::is_span<
+              meta::first_type_t<std::decay_t<Args>...>
+            >::value
+          )
         >
       >
       static basic_heap make_array(Args&&... elems);
@@ -4729,6 +4774,11 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_array(gsl::span<basic_heap const> elems);
 
       /**
@@ -4736,6 +4786,11 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_array(gsl::span<basic_buffer<RefCount> const> elems);
 
       /**
@@ -4743,6 +4798,11 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_array(gsl::span<basic_packet<RefCount> const> elems);
 
       /**
@@ -4756,6 +4816,11 @@ namespace dart {
        *  Otherwise, function will allocate the memory necessary to store the given
        *  string.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_string(shim::string_view val);
 
       /**
@@ -4763,6 +4828,11 @@ namespace dart {
        *  Integer factory function.
        *  Returns a new, non-finalized, integer with the given contents.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_integer(int64_t val) noexcept;
 
       /**
@@ -4770,6 +4840,11 @@ namespace dart {
        *  Decimal factory function.
        *  Returns a new, non-finalized, decimal with the given contents.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_decimal(double val) noexcept;
 
       /**
@@ -4777,6 +4852,11 @@ namespace dart {
        *  Boolean factory function.
        *  Returns a new, non-finalized, boolean with the given contents.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap make_boolean(bool val) noexcept;
 
       /**
@@ -4808,6 +4888,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_heap>::value
           &&
           convert::is_castable<ValueType, basic_heap>::value
@@ -4835,6 +4917,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_heap>::value
           &&
           convert::is_castable<ValueType, basic_heap>::value
@@ -4859,6 +4943,11 @@ namespace dart {
        *  auto nested = obj["nested"].remove_field("hello");
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap& remove_field(shim::string_view key) &;
 
       /**
@@ -4878,6 +4967,11 @@ namespace dart {
        *  auto nested = obj["nested"].remove_field("hello");
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       DART_NODISCARD basic_heap&& remove_field(shim::string_view key) &&;
 
       /**
@@ -4899,6 +4993,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -4923,6 +5019,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -4947,6 +5045,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_heap>::value
         >
       >
@@ -4971,6 +5071,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_heap>::value
         >
       >
@@ -4988,6 +5090,11 @@ namespace dart {
        *  auto nested = arr[0].pop_front().pop_front();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap& pop_front() &;
 
       /**
@@ -5002,6 +5109,11 @@ namespace dart {
        *  auto nested = arr[0].pop_front().pop_front();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       DART_NODISCARD basic_heap&& pop_front() &&;
 
       /**
@@ -5023,6 +5135,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_heap>::value
         >
       >
@@ -5047,6 +5161,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_heap>::value
         >
       >
@@ -5064,6 +5180,11 @@ namespace dart {
        *  auto nested = arr[0].pop_back().pop_back();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap& pop_back() &;
 
       /**
@@ -5078,6 +5199,11 @@ namespace dart {
        *  auto nested = arr[0].pop_back().pop_back();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap&& pop_back() &&;
 
       /**
@@ -5100,6 +5226,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_heap>::value
           &&
           convert::is_castable<ValueType, basic_heap>::value
@@ -5128,6 +5256,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_heap>::value
         >
       >
@@ -5146,6 +5276,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_heap>::value
           &&
           convert::is_castable<ValueType, basic_heap>::value
@@ -5166,6 +5298,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_heap>::value
         >
       >
@@ -5182,6 +5316,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -5196,6 +5332,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(iterator pos) -> iterator;
 
       /**
@@ -5207,7 +5348,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(basic_string<String> const& key) -> iterator;
       
       /**
@@ -5219,6 +5364,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(shim::string_view key) -> iterator;
 
       /**
@@ -5230,7 +5380,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(basic_number<Number> const& idx) -> iterator;
 
       /**
@@ -5242,6 +5396,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(size_type pos) -> iterator;
 
       /**
@@ -5251,6 +5410,11 @@ namespace dart {
        *  @details
        *  If this is object/array, will remove all subvalues.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       void clear();
 
       /**
@@ -5265,11 +5429,13 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
+          sizeof...(Args) % 2 == 0
+          &&
           meta::conjunction<
             convert::is_castable<Args, basic_heap>...
           >::value
-          &&
-          sizeof...(Args) % 2 == 0
         >
       >
       basic_heap inject(Args&&... pairs) const;
@@ -5284,6 +5450,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap inject(gsl::span<basic_heap const> pairs) const;
 
       /**
@@ -5296,6 +5467,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap inject(gsl::span<basic_buffer<RefCount> const> pairs) const;
 
       /**
@@ -5308,6 +5484,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap inject(gsl::span<basic_packet<RefCount> const> pairs) const;
 
       /**
@@ -5320,16 +5501,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
-      /**
-       *  @brief
-       *  Function "projects" a set of key-value pairs in the mathematical
-       *  sense that it creates a new packet containing the intersection of
-       *  the supplied keys, and those present in the original packet.
-       *
-       *  @details
-       *  Function provides a uniform interface for _efficient_ projection of
-       *  keys across the entire Dart API (also works for dart::buffer).
-       */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap project(std::initializer_list<shim::string_view> keys) const;
 
       /**
@@ -5342,6 +5518,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap project(gsl::span<std::string const> keys) const;
 
       /**
@@ -5354,6 +5535,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap project(gsl::span<shim::string_view const> keys) const;
 
       /*----- State Manipulation Functions -----*/
@@ -5367,6 +5553,11 @@ namespace dart {
        *  If used judiciously, can increase insertion performance.
        *  If used poorly, will definitely decrease insertion performance.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       void reserve(size_type count);
 
       /**
@@ -5380,6 +5571,8 @@ namespace dart {
        */
       template <class T = std::nullptr_t, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -5404,6 +5597,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap& definalize() &;
 
       /**
@@ -5425,6 +5623,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap const& definalize() const&;
 
       /**
@@ -5446,6 +5649,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap&& definalize() &&;
 
       /**
@@ -5467,6 +5675,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap const&& definalize() const&&;
 
       /**
@@ -5488,6 +5701,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap& lift() &;
 
       /**
@@ -5509,6 +5727,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap const& lift() const&;
 
       /**
@@ -5530,6 +5753,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap&& lift() &&;
 
       /**
@@ -5551,6 +5779,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap const&& lift() const&&;
 
       /**
@@ -5572,6 +5805,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer<RefCount> finalize() const;
 
       /**
@@ -5593,6 +5831,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer<RefCount> lower() const;
 
       /**
@@ -5631,7 +5874,11 @@ namespace dart {
        *  auto all_of_it = dart::heap::from_json<dart::parse_permissive>(json);
        *  ```
        */
-      template <unsigned parse_stack_size = default_parse_stack_size>
+      template <unsigned parse_stack_size = default_parse_stack_size, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap from_json(shim::string_view json);
 #elif DART_HAS_RAPIDJSON
       /**
@@ -5651,7 +5898,11 @@ namespace dart {
        *  auto all_of_it = dart::heap::from_json<dart::parse_permissive>(json);
        *  ```
        */
-      template <unsigned flags = parse_default>
+      template <unsigned flags = parse_default, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap from_json(shim::string_view json);
 #endif
 
@@ -5685,6 +5936,11 @@ namespace dart {
        *  At the time of this writing, parsing logic does not support YAML anchors, this will
        *  be added soon.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_heap from_yaml(shim::string_view yaml);
 #endif
 
@@ -5729,6 +5985,8 @@ namespace dart {
        */
       template <class Number, class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -5752,6 +6010,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -5796,6 +6056,8 @@ namespace dart {
        */
       template <class String, class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -5819,6 +6081,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -5862,6 +6126,8 @@ namespace dart {
        */
       template <class KeyType, class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
           &&
           convert::is_castable<T, basic_heap>::value
@@ -5974,6 +6240,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -6002,6 +6270,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_heap>::value
         >
       >
@@ -6536,6 +6806,25 @@ namespace dart {
        */
       auto rkvend() const -> std::tuple<reverse_iterator, reverse_iterator>;
 
+      /*----- Member Ownership Helpers -----*/
+
+      /**
+       *  @brief
+       *  Function calculates whether the current type is a non-owning view or not.
+       */
+      constexpr bool is_view() const noexcept;
+
+      /**
+       *  @brief
+       *  Function allows one to explicitly grab full ownership of the current view.
+       */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          !refcount::is_owner<RC>::value
+        >
+      >
+      auto as_owner() const noexcept;
+
     private:
 
       /*----- Private Types -----*/
@@ -6558,8 +6847,11 @@ namespace dart {
       using packet_fields = detail::packet_fields<RefCount>;
       using packet_elements = detail::packet_elements<RefCount>;
 
-      using fields_type = shareable_ptr<RefCount<packet_fields>>;
-      using elements_type = shareable_ptr<RefCount<packet_elements>>;
+      using fields_rc_type = RefCount<packet_fields>;
+      using elements_rc_type = RefCount<packet_elements>;
+
+      using fields_type = shareable_ptr<fields_rc_type>;
+      using elements_type = shareable_ptr<elements_rc_type>;
 
       using type_data = shim::variant<
         shim::monostate,
@@ -6574,6 +6866,8 @@ namespace dart {
 
       /*----- Private Lifecycle Functions -----*/
 
+      template <class TypeData>
+      basic_heap(detail::view_tag, TypeData const& data);
       basic_heap(detail::object_tag) :
         data(make_shareable<RefCount<packet_fields>>())
       {}
@@ -6633,13 +6927,17 @@ namespace dart {
       friend struct convert::detail::caster_impl<convert::detail::decimal_tag>;
       friend struct convert::detail::caster_impl<convert::detail::string_tag>;
 
-      template <template <class> class RC>
-      friend bool operator ==(basic_buffer<RC> const&, basic_heap<RC> const&);
+      template <template <class> class LhsRC, template <class> class RhsRC>
+      friend bool operator ==(basic_buffer<LhsRC> const&, basic_heap<RhsRC> const&);
       friend size_t detail::sso_bytes<RefCount>();
       friend class detail::object<RefCount>;
       friend class detail::array<RefCount>;
+      
+      template <template <class> class RC>
+      friend class basic_heap;
       friend class basic_buffer<RefCount>;
-      friend class basic_packet<RefCount>;
+      template <template <class> class RC>
+      friend class basic_packet;
 
   };
 
@@ -6762,6 +7060,8 @@ namespace dart {
       using flag = basic_flag<basic_buffer>;
       using null = basic_null<basic_buffer>;
 
+      using view = basic_buffer<view_ptr_context<RefCount>::template view_ptr>;
+
       using size_type = size_t;
       using reverse_iterator = std::reverse_iterator<iterator>;
 
@@ -6782,6 +7082,11 @@ namespace dart {
        *  Converting constructor.
        *  Explicitly converts a dart::heap into a dart::buffer.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_buffer(basic_heap<RefCount> const& heap);
 
       /**
@@ -6794,6 +7099,11 @@ namespace dart {
        *  Given buffer pointer need not be well aligned, function will
        *  internally handle alignment requirements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_buffer(gsl::span<gsl::byte const> buffer) :
         raw({detail::raw_type::object, buffer.data()}),
         buffer_ref(allocate_pointer(buffer))
@@ -6806,6 +7116,11 @@ namespace dart {
        *  @details
        *  Reconstitutes a previously finalized packet from a buffer of bytes.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_buffer(shareable_ptr<RefCount<gsl::byte const>> buffer) :
         raw({detail::raw_type::object, buffer.get()}),
         buffer_ref(validate_pointer(std::move(buffer)))
@@ -6822,7 +7137,11 @@ namespace dart {
        *  Function is so heavily overloaded because the portability of
        *  std::unique_ptr converting constructors has been pretty flakey in practice.
        */
-      template <class Del>
+      template <class Del, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_buffer(std::unique_ptr<gsl::byte const[], Del>&& buffer) :
         raw({detail::raw_type::object, buffer.get()}),
         buffer_ref(normalize(validate_pointer(std::move(buffer))))
@@ -6839,7 +7158,11 @@ namespace dart {
        *  Function is so heavily overloaded because the portability of
        *  std::unique_ptr converting constructors has been pretty flakey in practice.
        */
-      template <class Del>
+      template <class Del, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_buffer(std::unique_ptr<gsl::byte const, Del>&& buffer) :
         raw({detail::raw_type::object, buffer.get()}),
         buffer_ref(normalize(validate_pointer(std::move(buffer))))
@@ -6856,7 +7179,11 @@ namespace dart {
        *  Function is so heavily overloaded because the portability of
        *  std::unique_ptr converting constructors has been pretty flakey in practice.
        */
-      template <class Del>
+      template <class Del, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_buffer(std::unique_ptr<gsl::byte, Del>&& buffer) :
         raw({detail::raw_type::object, buffer.get()}),
         buffer_ref(normalize(validate_pointer(std::move(buffer))))
@@ -6936,7 +7263,11 @@ namespace dart {
        *  auto deep = arr[0][1][2];
        *  ```
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& operator [](basic_number<Number> const& idx) &&;
 
       /**
@@ -6967,6 +7298,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& operator [](size_type index) &&;
 
       /**
@@ -6998,7 +7334,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& operator [](basic_string<String> const& key) &&;
 
       /**
@@ -7029,6 +7369,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& operator [](shim::string_view key) &&;
 
       /**
@@ -7065,6 +7410,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -7083,7 +7430,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator ==(basic_buffer const& other) const noexcept;
+      template <template <class> class OtherRC>
+      bool operator ==(basic_buffer<OtherRC> const& other) const noexcept;
 
       /**
        *  @brief
@@ -7098,7 +7446,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_buffer const& other) const noexcept;
+      template <template <class> class OtherRC>
+      bool operator !=(basic_buffer<OtherRC> const& other) const noexcept;
 
       /**
        *  @brief
@@ -7131,6 +7480,14 @@ namespace dart {
        *  Returns true in all other situations.
        */
       explicit operator bool() const noexcept;
+
+      /**
+       *  @brief
+       *  Operator allows for converting the current buffer instance into a
+       *  non-owning, read-only, view
+       */
+      operator view() const& noexcept;
+      operator view() && = delete;
 
       /**
        *  @brief
@@ -7199,6 +7556,8 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           sizeof...(Args) % 2 == 0
         >
       >
@@ -7214,6 +7573,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_buffer make_object(gsl::span<basic_heap<RefCount> const> pairs);
 
       /**
@@ -7226,6 +7590,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_buffer make_object(gsl::span<basic_buffer<RefCount> const> pairs);
 
       /**
@@ -7238,6 +7607,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_buffer make_object(gsl::span<basic_packet<RefCount> const> pairs);
 
       /**
@@ -7261,11 +7635,13 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
+          sizeof...(Args) % 2 == 0
+          &&
           meta::conjunction<
             convert::is_castable<Args, basic_packet<RefCount>>...
           >::value
-          &&
-          sizeof...(Args) % 2 == 0
         >
       >
       basic_buffer inject(Args&&... pairs) const;
@@ -7280,6 +7656,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer inject(gsl::span<basic_heap<RefCount> const> pairs) const;
 
       /**
@@ -7292,6 +7673,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer inject(gsl::span<basic_buffer const> pairs) const;
 
       /**
@@ -7304,6 +7690,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer inject(gsl::span<basic_packet<RefCount> const> pairs) const;
 
       /**
@@ -7316,6 +7707,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer project(std::initializer_list<shim::string_view> keys) const;
 
       /**
@@ -7328,6 +7724,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer project(gsl::span<std::string const> keys) const;
 
       /**
@@ -7340,6 +7741,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer project(gsl::span<shim::string_view const> keys) const;
 
       /*----- State Manipulation Functions -----*/
@@ -7363,6 +7769,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::buffer::finalize, the reverse can be accomplished using dart::buffer::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap<RefCount> definalize() const;
 
       /**
@@ -7384,6 +7795,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::buffer::finalize, the reverse can be accomplished using dart::buffer::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_heap<RefCount> lift() const;
 
       /**
@@ -7405,6 +7821,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer& finalize() &;
 
       /**
@@ -7426,6 +7847,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer const& finalize() const&;
 
       /**
@@ -7447,6 +7873,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& finalize() &&;
 
       /**
@@ -7468,6 +7899,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer const&& finalize() const&&;
 
       /**
@@ -7489,6 +7925,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer& lower() &;
 
       /**
@@ -7510,6 +7951,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer const& lower() const&;
 
       /**
@@ -7531,6 +7977,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& lower() &&;
 
       /**
@@ -7552,6 +8003,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::heap::finalize, the reverse can be accomplished using dart::heap::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer const&& lower() const&&;
 
       /**
@@ -7590,7 +8046,11 @@ namespace dart {
        *  auto all_of_it = dart::heap::from_json<dart::parse_permissive>(json);
        *  ```
        */
-      template <unsigned parse_stack_size = default_parse_stack_size>
+      template <unsigned parse_stack_size = default_parse_stack_size, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_buffer from_json(shim::string_view json);
 #elif DART_HAS_RAPIDJSON
       /**
@@ -7610,7 +8070,11 @@ namespace dart {
        *  auto all_of_it = dart::buffer::from_json<dart::parse_permissive>(json);
        *  ```
        */
-      template <unsigned flags = parse_default>
+      template <unsigned flags = parse_default, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_buffer from_json(shim::string_view json);
 #endif
 
@@ -7644,6 +8108,11 @@ namespace dart {
        *  At the time of this writing, parsing logic does not support YAML anchors, this will
        *  be added soon.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_buffer from_yaml(shim::string_view yaml);
 #endif
 
@@ -7677,7 +8146,11 @@ namespace dart {
        *  auto deep = arr[0][1][2];
        *  ```
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& get(basic_number<Number> const& idx) &&;
 
       /**
@@ -7738,7 +8211,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& get(basic_string<String> const& key) &&;
 
       /**
@@ -7769,6 +8246,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& get(shim::string_view key) &&;
 
       /**
@@ -7807,6 +8289,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -7846,7 +8330,11 @@ namespace dart {
        *  auto deep = arr[0][1][2];
        *  ```
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& at(basic_number<Number> const& idx) &&;
 
       /**
@@ -7876,6 +8364,11 @@ namespace dart {
        *  auto deep = arr[0][1][2];
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& at(size_type index) &&;
 
       /**
@@ -7907,7 +8400,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& at(basic_string<String> const& key) &&;
 
       /**
@@ -7938,6 +8435,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& at(shim::string_view key) &&;
 
       /**
@@ -7976,6 +8478,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -8006,6 +8510,11 @@ namespace dart {
        *  auto deep = obj["first"]["second"]["third"];
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& at_front() &&;
 
       /**
@@ -8033,6 +8542,11 @@ namespace dart {
        *  auto deep = obj["first"]["second"]["third"];
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& at_back() &&;
 
       /**
@@ -8055,6 +8569,11 @@ namespace dart {
        *  returns the first element.
        *  Throws otherwise.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& front() &&;
 
       /**
@@ -8077,6 +8596,11 @@ namespace dart {
        *  returns the last element.
        *  Throws otherwise.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_buffer&& back() &&;
 
       /**
@@ -8666,11 +9190,31 @@ namespace dart {
        */
       auto rkvend() const -> std::tuple<reverse_iterator, reverse_iterator>;
 
+      /*----- Member Ownership Helpers -----*/
+
+      /**
+       *  @brief
+       *  Function calculates whether the current type is a non-owning view or not.
+       */
+      constexpr bool is_view() const noexcept;
+
+      /**
+       *  @brief
+       *  Function allows one to explicitly grab full ownership of the current view.
+       */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          !refcount::is_owner<RC>::value
+        >
+      >
+      auto as_owner() const noexcept;
+
     private:
 
       /*----- Private Types -----*/
 
       using buffer_ref_type = detail::buffer_refcount_type<RefCount>;
+      using ref_type = typename buffer_ref_type::value_type;
 
       /*----- Private Lifecycle Functions -----*/
 
@@ -8692,10 +9236,13 @@ namespace dart {
 
       /*----- Friends -----*/
 
-      friend class basic_packet<RefCount>;
-      friend struct detail::buffer_builder<RefCount>;
       template <template <class> class RC>
-      friend bool operator ==(basic_buffer<RC> const&, basic_heap<RC> const&);
+      friend class basic_buffer;
+      template <template <class> class RC>
+      friend class basic_packet;
+      friend struct detail::buffer_builder<RefCount>;
+      template <template <class> class LhsRC, template <class> class RhsRC>
+      friend bool operator ==(basic_buffer<LhsRC> const&, basic_heap<RhsRC> const&);
 
   };
 
@@ -8843,6 +9390,8 @@ namespace dart {
       using flag = basic_flag<basic_packet>;
       using null = basic_null<basic_packet>;
 
+      using view = basic_packet<view_ptr_context<RefCount>::template view_ptr>;
+
       using size_type = size_t;
       using reverse_iterator = std::reverse_iterator<iterator>;
 
@@ -8887,6 +9436,11 @@ namespace dart {
        *  Given buffer pointer need not be well aligned, function will
        *  internally handle alignment requirements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_packet(gsl::span<gsl::byte const> buffer) :
         impl(basic_buffer<RefCount>(buffer))
       {}
@@ -8898,6 +9452,11 @@ namespace dart {
        *  @details
        *  Reconstitutes a previously finalized packet from a buffer of bytes.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_packet(shareable_ptr<RefCount<gsl::byte const>> buffer) :
         impl(basic_buffer<RefCount>(std::move(buffer)))
       {}
@@ -8909,7 +9468,11 @@ namespace dart {
        *  @details
        *  Reconstitutes a previously finalized packet from a buffer of bytes.
        */
-      template <class Del>
+      template <class Del, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_packet(std::unique_ptr<gsl::byte const[], Del>&& buffer) :
         impl(basic_buffer<RefCount>(std::move(buffer)))
       {}
@@ -8921,7 +9484,11 @@ namespace dart {
        *  @details
        *  Reconstitutes a previously finalized packet from a buffer of bytes.
        */
-      template <class Del>
+      template <class Del, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_packet(std::unique_ptr<gsl::byte const, Del>&& buffer) :
         impl(basic_buffer<RefCount>(std::move(buffer)))
       {}
@@ -8933,7 +9500,11 @@ namespace dart {
        *  @details
        *  Reconstitutes a previously finalized packet from a buffer of bytes.
        */
-      template <class Del>
+      template <class Del, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       explicit basic_packet(std::unique_ptr<gsl::byte, Del>&& buffer) :
         impl(basic_buffer<RefCount>(std::move(buffer)))
       {}
@@ -9013,7 +9584,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& operator [](basic_number<Number> const& idx) &&;
 
       /**
@@ -9044,6 +9619,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& operator [](size_type index) &&;
 
       /**
@@ -9075,7 +9655,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& operator [](basic_string<String> const& key) &&;
 
       /**
@@ -9106,6 +9690,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& operator [](shim::string_view key) &&;
 
       /**
@@ -9143,6 +9732,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -9161,8 +9752,49 @@ namespace dart {
        *  
        *  @remarks
        *  "Do as vector does"
+       *  Operator == is overloaded to ensure comparability with the rest of
+       *  the dart types.
+       *  We want comparability across refcounters, but conversions aren't
+       *  considered for template parameters.
        */
       bool operator ==(basic_packet const& other) const noexcept;
+
+      /**
+       *  @brief
+       *  Equality operator.
+       *  
+       *  @details
+       *  All packet types always return deep equality (aggregates included).
+       *  While idiomatic for C++, this means that non-finalized object comparisons
+       *  can be reasonably expensive.
+       *  Finalized comparisons, however, use memcmp to compare the underlying
+       *  byte buffers, and is _stupendously_ fast.
+       *  
+       *  @remarks
+       *  "Do as vector does"
+       */
+      template <template <class> class OtherRC>
+      bool operator ==(basic_packet<OtherRC> const& other) const noexcept;
+
+      /**
+       *  @brief
+       *  Equality operator.
+       *  
+       *  @details
+       *  All packet types always return deep equality (aggregates included).
+       *  While idiomatic for C++, this means that non-finalized object comparisons
+       *  can be reasonably expensive.
+       *  Finalized comparisons, however, use memcmp to compare the underlying
+       *  byte buffers, and is _stupendously_ fast.
+       *  
+       *  @remarks
+       *  "Do as vector does"
+       *  Operator == is overloaded to ensure comparability with the rest of
+       *  the dart types.
+       *  We want comparability across refcounters, but conversions aren't
+       *  considered for template parameters.
+       */
+      bool operator !=(basic_packet const& other) const noexcept;
 
       /**
        *  @brief
@@ -9178,7 +9810,8 @@ namespace dart {
        *  @remarks
        *  "Do as vector does"
        */
-      bool operator !=(basic_packet const& other) const noexcept;
+      template <template <class> class OtherRC>
+      bool operator !=(basic_packet<OtherRC> const& other) const noexcept;
 
       /**
        *  @brief
@@ -9211,6 +9844,14 @@ namespace dart {
        *  Returns true in all other situations.
        */
       explicit operator bool() const noexcept;
+
+      /**
+       *  @brief
+       *  Operator allows for converting the current packet instance into a
+       *  non-owning, read-only, view
+       */
+      operator view() const& noexcept;
+      operator view() && = delete;
 
       /**
        *  @brief
@@ -9294,6 +9935,8 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           sizeof...(Args) % 2 == 0
         >
       >
@@ -9309,6 +9952,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_object(gsl::span<basic_heap<RefCount> const> pairs);
 
       /**
@@ -9321,6 +9969,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_object(gsl::span<basic_buffer<RefCount> const> pairs);
 
       /**
@@ -9333,6 +9986,11 @@ namespace dart {
        *  first of each pair is convertible to a dart::heap string, and the second of
        *  each pair is convertible into a dart::heap of any type.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_object(gsl::span<basic_packet<RefCount> const> pairs);
 
       /**
@@ -9340,7 +9998,19 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
-      template <class... Args>
+      template <class... Args, class =
+        std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
+          (
+            (sizeof...(Args) > 1)
+            ||
+            !meta::is_span<
+              meta::first_type_t<std::decay_t<Args>...>
+            >::value
+          )
+        >
+      >
       static basic_packet make_array(Args&&... elems);
 
       /**
@@ -9348,6 +10018,11 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_array(gsl::span<basic_heap<RefCount> const> elems);
 
       /**
@@ -9355,6 +10030,11 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_array(gsl::span<basic_buffer<RefCount> const> elems);
 
       /**
@@ -9362,6 +10042,11 @@ namespace dart {
        *  Array factory function.
        *  Returns a new, non-finalized, array with the given sequence of elements.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_array(gsl::span<basic_packet const> elems);
 
       /**
@@ -9375,6 +10060,11 @@ namespace dart {
        *  Otherwise, function will allocate the memory necessary to store the given
        *  string.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_string(shim::string_view val);
 
       /**
@@ -9382,6 +10072,11 @@ namespace dart {
        *  Integer factory function.
        *  Returns a new, non-finalized, integer with the given contents.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_integer(int64_t val) noexcept;
 
       /**
@@ -9389,6 +10084,11 @@ namespace dart {
        *  Decimal factory function.
        *  Returns a new, non-finalized, decimal with the given contents.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_decimal(double val) noexcept;
 
       /**
@@ -9396,6 +10096,11 @@ namespace dart {
        *  Boolean factory function.
        *  Returns a new, non-finalized, boolean with the given contents.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet make_boolean(bool val) noexcept;
 
       /**
@@ -9427,6 +10132,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_packet>::value
           &&
           convert::is_castable<ValueType, basic_packet>::value
@@ -9454,6 +10161,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_packet>::value
           &&
           convert::is_castable<ValueType, basic_packet>::value
@@ -9478,6 +10187,11 @@ namespace dart {
        *  auto nested = obj["nested"].remove_field("hello");
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& remove_field(shim::string_view key) &;
 
       /**
@@ -9497,7 +10211,12 @@ namespace dart {
        *  auto nested = obj["nested"].remove_field("hello");
        *  ```
        */
-      basic_packet&& remove_field(shim::string_view key) &&;
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
+      DART_NODISCARD basic_packet&& remove_field(shim::string_view key) &&;
 
       /**
        *  @brief
@@ -9518,6 +10237,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -9542,6 +10263,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -9566,6 +10289,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_packet>::value
         >
       >
@@ -9590,6 +10315,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_packet>::value
         >
       >
@@ -9607,6 +10334,11 @@ namespace dart {
        *  auto nested = arr[0].pop_front().pop_front();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& pop_front() &;
 
       /**
@@ -9621,6 +10353,11 @@ namespace dart {
        *  auto nested = arr[0].pop_front().pop_front();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       DART_NODISCARD basic_packet&& pop_front() &&;
 
       /**
@@ -9642,6 +10379,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_packet>::value
         >
       >
@@ -9666,6 +10405,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_packet>::value
         >
       >
@@ -9683,6 +10424,11 @@ namespace dart {
        *  auto nested = arr[0].pop_back().pop_back();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& pop_back() &;
 
       /**
@@ -9697,6 +10443,11 @@ namespace dart {
        *  auto nested = arr[0].pop_back().pop_back();
        *  ```
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       DART_NODISCARD basic_packet&& pop_back() &&;
 
       /**
@@ -9719,6 +10470,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_packet>::value
           &&
           convert::is_castable<ValueType, basic_packet>::value
@@ -9747,6 +10500,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_packet>::value
         >
       >
@@ -9765,6 +10520,8 @@ namespace dart {
        */
       template <class KeyType, class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<KeyType, basic_packet>::value
           &&
           convert::is_castable<ValueType, basic_packet>::value
@@ -9785,6 +10542,8 @@ namespace dart {
        */
       template <class ValueType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<ValueType, basic_packet>::value
         >
       >
@@ -9801,6 +10560,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -9815,6 +10576,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(iterator pos) -> iterator;
 
       /**
@@ -9826,7 +10592,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(basic_string<String> const& key) -> iterator;
 
       /**
@@ -9838,6 +10608,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(shim::string_view key) -> iterator;
 
       /**
@@ -9849,7 +10624,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(basic_number<Number> const& idx) -> iterator;
 
       /**
@@ -9861,6 +10640,11 @@ namespace dart {
        *  returns the end iterator, otherwise it returns an iterator to one past the element
        *  removed.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       auto erase(size_type pos) -> iterator;
 
       /**
@@ -9870,6 +10654,11 @@ namespace dart {
        *  @details
        *  If this is a non-finalized object/array, function will remove all subvalues.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       void clear();
 
       /**
@@ -9884,11 +10673,13 @@ namespace dart {
        */
       template <class... Args, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
+          sizeof...(Args) % 2 == 0
+          &&
           meta::conjunction<
             convert::is_castable<Args, basic_packet>...
           >::value
-          &&
-          sizeof...(Args) % 2 == 0
         >
       >
       basic_packet inject(Args&&... pairs) const;
@@ -9903,6 +10694,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet inject(gsl::span<basic_heap<RefCount> const> pairs) const;
 
       /**
@@ -9915,6 +10711,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet inject(gsl::span<basic_buffer<RefCount> const> pairs) const;
 
       /**
@@ -9927,6 +10728,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ injection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet inject(gsl::span<basic_packet const> pairs) const;
 
       /**
@@ -9939,6 +10745,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet project(std::initializer_list<shim::string_view> keys) const;
 
       /**
@@ -9951,6 +10762,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet project(gsl::span<std::string const> keys) const;
 
       /**
@@ -9963,6 +10779,11 @@ namespace dart {
        *  Function provides a uniform interface for _efficient_ projection of
        *  keys across the entire Dart API (also works for dart::buffer).
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet project(gsl::span<shim::string_view const> keys) const;
 
       /*----- State Manipulation Functions -----*/
@@ -9976,6 +10797,11 @@ namespace dart {
        *  If used judiciously, can increase insertion performance.
        *  If used poorly, will definitely decrease insertion performance.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       void reserve(size_type count);
 
       /**
@@ -10012,6 +10838,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& definalize() &;
 
       /**
@@ -10032,6 +10863,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& definalize() &&;
 
       /**
@@ -10052,6 +10888,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& lift() &;
 
       /**
@@ -10072,6 +10913,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& lift() &&;
 
       /**
@@ -10092,6 +10938,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& finalize() &;
 
       /**
@@ -10112,6 +10963,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& finalize() &&;
 
       /**
@@ -10132,6 +10988,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet& lower() &;
 
       /**
@@ -10152,6 +11013,11 @@ namespace dart {
        *  Switching from dynamic to finalized mode is accomplished via a call to
        *  dart::packet::finalize, the reverse can be accomplished using dart::packet::definalize.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& lower() &&;
 
       /**
@@ -10192,7 +11058,11 @@ namespace dart {
        *  auto all_of_it = dart::heap::from_json<dart::parse_permissive>(json);
        *  ```
        */
-      template <unsigned parse_stack_size = default_parse_stack_size>
+      template <unsigned parse_stack_size = default_parse_stack_size, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet from_json(shim::string_view json, bool finalized = true);
 #elif DART_HAS_RAPIDJSON
       /**
@@ -10212,8 +11082,12 @@ namespace dart {
        *  auto all_of_it = dart::packet::from_json<dart::parse_permissive>(json);
        *  ```
        */
-      template <unsigned flags = parse_default>
-      static basic_packet from_json(shim::string_view json, bool finalize = true);
+      template <unsigned flags = parse_default, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
+      static basic_packet from_json(shim::string_view json, bool finalize = false);
 #endif
 
 #if DART_HAS_RAPIDJSON
@@ -10246,6 +11120,11 @@ namespace dart {
        *  At the time of this writing, parsing logic does not support YAML anchors, this will
        *  be added soon.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       static basic_packet from_yaml(shim::string_view yaml, bool finalized = true);
 #endif
 
@@ -10280,7 +11159,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& get(basic_number<Number> const& idx) &&;
 
       /**
@@ -10311,6 +11194,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& get(size_type index) &&;
 
       /**
@@ -10331,6 +11219,8 @@ namespace dart {
        */
       template <class Number, class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_packet>::value
         >
       >
@@ -10354,6 +11244,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_packet>::value
         >
       >
@@ -10388,7 +11280,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& get(basic_string<String> const& key) &&;
 
       /**
@@ -10419,6 +11315,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& get(shim::string_view key) &&;
 
       /**
@@ -10439,6 +11340,8 @@ namespace dart {
        */
       template <class String, class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_packet>::value
         >
       >
@@ -10462,6 +11365,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_packet>::value
         >
       >
@@ -10504,6 +11409,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -10531,6 +11438,8 @@ namespace dart {
        */
       template <class KeyType, class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
           &&
           convert::is_castable<T, basic_packet>::value
@@ -10573,7 +11482,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class Number>
+      template <class Number, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& at(basic_number<Number> const& idx) &&;
 
       /**
@@ -10604,6 +11517,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& at(size_type index) &&;
 
       /**
@@ -10635,7 +11553,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
-      template <class String>
+      template <class String, template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& at(basic_string<String> const& key) &&;
 
       /**
@@ -10666,6 +11588,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& at(shim::string_view key) &&;
 
       /**
@@ -10705,6 +11632,8 @@ namespace dart {
        */
       template <class KeyType, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           meta::is_dartlike<KeyType const&>::value
         >
       >
@@ -10736,6 +11665,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& at_front() &&;
 
       /**
@@ -10764,6 +11698,11 @@ namespace dart {
        *  ```
        *  and so all classes that can wrap dart::buffer also implement this overload.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& at_back() &&;
 
       /**
@@ -10786,6 +11725,11 @@ namespace dart {
        *  returns the first element.
        *  Throws otherwise.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& front() &&;
 
       /**
@@ -10800,6 +11744,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_packet>::value
         >
       >
@@ -10825,6 +11771,11 @@ namespace dart {
        *  returns the last element.
        *  Throws otherwise.
        */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          refcount::is_owner<RC>::value
+        >
+      >
       basic_packet&& back() &&;
 
       /**
@@ -10839,6 +11790,8 @@ namespace dart {
        */
       template <class T, class =
         std::enable_if_t<
+          refcount::is_owner<RefCount>::value
+          &&
           convert::is_castable<T, basic_packet>::value
         >
       >
@@ -11434,6 +12387,25 @@ namespace dart {
        */
       auto rkvend() const -> std::tuple<reverse_iterator, reverse_iterator>;
 
+      /*----- Member Ownership Helpers -----*/
+
+      /**
+       *  @brief
+       *  Function calculates whether the current type is a non-owning view or not.
+       */
+      constexpr bool is_view() const noexcept;
+
+      /**
+       *  @brief
+       *  Function allows one to explicitly grab full ownership of the current view.
+       */
+      template <template <class> class RC = RefCount, class =
+        std::enable_if_t<
+          !refcount::is_owner<RC>::value
+        >
+      >
+      auto as_owner() const noexcept;
+
     private:
 
       /*----- Private Types -----*/
@@ -11471,10 +12443,12 @@ namespace dart {
       friend struct convert::detail::caster_impl<convert::detail::decimal_tag>;
       friend struct convert::detail::caster_impl<convert::detail::string_tag>;
 
+      template <template <class> class LhsRC, template <class> class RhsRC>
+      friend bool operator ==(basic_buffer<LhsRC> const&, basic_packet<RhsRC> const&);
+      template <template <class> class LhsRC, template <class> class RhsRC>
+      friend bool operator ==(basic_heap<LhsRC> const&, basic_packet<RhsRC> const&);
       template <template <class> class RC>
-      friend bool operator ==(basic_buffer<RC> const&, basic_packet<RC> const&);
-      template <template <class> class RC>
-      friend bool operator ==(basic_heap<RC> const&, basic_packet<RC> const&);
+      friend class dart::basic_packet;
       friend class detail::object<RefCount>;
       friend struct detail::buffer_builder<RefCount>;
 
@@ -11519,7 +12493,7 @@ namespace dart {
    *  sajson.
    */
   template <unsigned parse_stack_size = default_parse_stack_size>
-  packet from_json(shim::string_view json, bool finalize = true) {
+  packet from_json(shim::string_view json, bool finalize = false) {
     return packet::from_json<parse_stack_size>(json, finalize);
   }
 
@@ -11532,7 +12506,7 @@ namespace dart {
    *  sajson.
    */
   template <unsigned parse_stack_size = default_parse_stack_size>
-  packet parse(shim::string_view json, bool finalize = true) {
+  packet parse(shim::string_view json, bool finalize = false) {
     return from_json<parse_stack_size>(json, finalize);
   }
 #elif DART_HAS_RAPIDJSON
@@ -11554,7 +12528,7 @@ namespace dart {
    *  ```
    */
   template <unsigned flags = parse_default>
-  packet from_json(shim::string_view json, bool finalize = true) {
+  packet from_json(shim::string_view json, bool finalize = false) {
     return packet::from_json<flags>(json, finalize);
   }
 
@@ -11576,7 +12550,7 @@ namespace dart {
    *  ```
    */
   template <unsigned flags = parse_default>
-  packet parse(shim::string_view json, bool finalize = true) {
+  packet parse(shim::string_view json, bool finalize = false) {
     return from_json<flags>(json, finalize);
   }
 #endif

--- a/include/dart/dart_api.tcc
+++ b/include/dart/dart_api.tcc
@@ -40,6 +40,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>::basic_buffer(basic_heap<RefCount> const& heap) {
     if (!heap.is_object()) {
       throw type_error("dart::buffer can only be constructed from an object heap");
@@ -118,39 +119,48 @@ namespace dart {
   }
 
   template <class Object>
-  bool basic_object<Object>::operator ==(basic_object const& other) const noexcept {
+  template <class OtherObject>
+  bool basic_object<Object>::operator ==(basic_object<OtherObject> const& other) const noexcept {
     return val == other.val;
   }
 
   template <class Array>
-  bool basic_array<Array>::operator ==(basic_array const& other) const noexcept {
+  template <class OtherArray>
+  bool basic_array<Array>::operator ==(basic_array<OtherArray> const& other) const noexcept {
     return val == other.val;
   }
 
   template <class String>
-  bool basic_string<String>::operator ==(basic_string const& other) const noexcept {
+  template <class OtherString>
+  bool basic_string<String>::operator ==(basic_string<OtherString> const& other) const noexcept {
     return val == other.val;
   }
 
   template <class Number>
-  bool basic_number<Number>::operator ==(basic_number const& other) const noexcept {
+  template <class OtherNumber>
+  bool basic_number<Number>::operator ==(basic_number<OtherNumber> const& other) const noexcept {
     return val == other.val;
   }
 
   template <class Boolean>
-  bool basic_flag<Boolean>::operator ==(basic_flag const& other) const noexcept {
+  template <class OtherBoolean>
+  bool basic_flag<Boolean>::operator ==(basic_flag<OtherBoolean> const& other) const noexcept {
     return val == other.val;
   }
 
   template <class Null>
-  constexpr bool basic_null<Null>::operator ==(basic_null const&) const noexcept {
+  template <class OtherNull>
+  constexpr bool basic_null<Null>::operator ==(basic_null<OtherNull> const&) const noexcept {
     return true;
   }
 
   template <template <class> class RefCount>
-  bool basic_heap<RefCount>::operator ==(basic_heap const& other) const noexcept {
+  template <template <class> class OtherRC>
+  bool basic_heap<RefCount>::operator ==(basic_heap<OtherRC> const& other) const noexcept {
     // Check if we're comparing against ourselves.
-    if (this == &other) return true;
+    // Cast is necessary to ensure validity if we're comparing
+    // against a different refcounter.
+    if (static_cast<void const*>(this) == static_cast<void const*>(&other)) return true;
 
     // Check if we're even the same type.
     if (is_null() && other.is_null()) return true;
@@ -172,9 +182,12 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  bool basic_buffer<RefCount>::operator ==(basic_buffer const& other) const noexcept {
+  template <template <class> class OtherRC>
+  bool basic_buffer<RefCount>::operator ==(basic_buffer<OtherRC> const& other) const noexcept {
     // Check if we're comparing against ourselves.
-    if (this == &other) return true;
+    // Cast is necessary to ensure validity if we're comparing
+    // against a different refcounter.
+    if (static_cast<void const*>(this) == static_cast<void const*>(&other)) return true;
 
     // Check if we're sure we're even the same type.
     if (is_null() && other.is_null()) return true;
@@ -187,53 +200,75 @@ namespace dart {
 
   template <template <class> class RefCount>
   bool basic_packet<RefCount>::operator ==(basic_packet const& other) const noexcept {
+    return this->operator ==<RefCount>(other);
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class OtherRC>
+  bool basic_packet<RefCount>::operator ==(basic_packet<OtherRC> const& other) const noexcept {
     // Check if we're comparing against ourselves.
-    if (this == &other) return true;
+    // Cast is necessary to ensure validity if we're comparing
+    // against a different refcounter.
+    if (static_cast<void const*>(this) == static_cast<void const*>(&other)) return true;
     return shim::visit([] (auto& lhs, auto& rhs) { return lhs == rhs; }, impl, other.impl);
   }
 
   template <class Object>
-  bool basic_object<Object>::operator !=(basic_object const& other) const noexcept {
+  template <class OtherObject>
+  bool basic_object<Object>::operator !=(basic_object<OtherObject> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <class Array>
-  bool basic_array<Array>::operator !=(basic_array const& other) const noexcept {
+  template <class OtherArray>
+  bool basic_array<Array>::operator !=(basic_array<OtherArray> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <class String>
-  bool basic_string<String>::operator !=(basic_string const& other) const noexcept {
+  template <class OtherString>
+  bool basic_string<String>::operator !=(basic_string<OtherString> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <class Number>
-  bool basic_number<Number>::operator !=(basic_number const& other) const noexcept {
+  template <class OtherNumber>
+  bool basic_number<Number>::operator !=(basic_number<OtherNumber> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <class Boolean>
-  bool basic_flag<Boolean>::operator !=(basic_flag const& other) const noexcept {
+  template <class OtherBoolean>
+  bool basic_flag<Boolean>::operator !=(basic_flag<OtherBoolean> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <class Null>
-  constexpr bool basic_null<Null>::operator !=(basic_null const& other) const noexcept {
+  template <class OtherNull>
+  constexpr bool basic_null<Null>::operator !=(basic_null<OtherNull> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <template <class> class RefCount>
-  bool basic_heap<RefCount>::operator !=(basic_heap const& other) const noexcept {
+  template <template <class> class OtherRC>
+  bool basic_heap<RefCount>::operator !=(basic_heap<OtherRC> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <template <class> class RefCount>
-  bool basic_buffer<RefCount>::operator !=(basic_buffer const& other) const noexcept {
+  template <template <class> class OtherRC>
+  bool basic_buffer<RefCount>::operator !=(basic_buffer<OtherRC> const& other) const noexcept {
     return !(*this == other);
   }
 
   template <template <class> class RefCount>
   bool basic_packet<RefCount>::operator !=(basic_packet const& other) const noexcept {
+    return this->operator !=<RefCount>(other);
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class OtherRC>
+  bool basic_packet<RefCount>::operator !=(basic_packet<OtherRC> const& other) const noexcept {
     return !(*this == other);
   }
 
@@ -383,6 +418,26 @@ namespace dart {
   basic_packet<RefCount>::operator bool() const noexcept {
     if (!is_boolean()) return !is_null();
     else return boolean();
+  }
+
+  template <template <class> class RefCount>
+  basic_heap<RefCount>::operator view() const& noexcept {
+    return view {detail::view_tag {}, data};
+  }
+
+  template <template <class> class RefCount>
+  basic_buffer<RefCount>::operator view() const& noexcept {
+    view tmp;
+    tmp.raw = raw;
+    tmp.buffer_ref = typename view::ref_type {buffer_ref.raw()};
+    return tmp;
+  }
+
+  template <template <class> class RefCount>
+  basic_packet<RefCount>::operator view() const& noexcept {
+    return shim::visit([] (auto& impl) -> view {
+      return typename std::decay_t<decltype(impl)>::view {impl};
+    }, impl);
   }
 
   template <class String>
@@ -555,13 +610,13 @@ namespace dart {
       // If the key was already present, insert will fail without consuming our value.
       // Overwrite it.
       if (!res.second) res.first->second = std::move(tmp_value);
-      return detail::dn_iterator<RefCount> {res.first, [] (auto& it) { return it->second; }};
+      return detail::dynamic_iterator<RefCount> {res.first, [] (auto& it) -> auto const& { return it->second; }};
     } else if (tmp_key.is_integer()) {
       auto& elements = get_elements();
       auto pos = static_cast<size_type>(tmp_key.integer());
       if (pos > elements.size()) throw std::out_of_range("dart::heap cannot insert at out of range index");
       auto new_it = elements.insert(elements.begin() + pos, std::forward<decltype(tmp_value)>(tmp_value));
-      return detail::dn_iterator<RefCount> {new_it, [] (auto& it) { return *it; }};
+      return detail::dynamic_iterator<RefCount> {new_it, [] (auto& it) -> auto const& { return *it; }};
     } else {
       throw type_error("dart::heap cannot insert keys with non string/integer types");
     }
@@ -577,7 +632,7 @@ namespace dart {
   template <class ValueType, class>
   auto basic_heap<RefCount>::insert(iterator pos, ValueType&& value) -> iterator {
     // Dig all the way down and get the underlying iterator layout.
-    using elements_layout = typename detail::dn_iterator<RefCount>::elements_layout;
+    using elements_layout = typename detail::dynamic_iterator<RefCount>::elements_layout;
 
     // Make sure our iterator can be used.
     if (!pos) throw std::invalid_argument("dart::heap cannot insert from a valueless iterator");
@@ -617,14 +672,14 @@ namespace dart {
       auto it = fields.find(tmp_key);
       if (it == fields.end()) throw std::out_of_range("dart::heap cannot set a non-existent key");
       it->second = std::forward<decltype(tmp_val)>(tmp_val);
-      return detail::dn_iterator<RefCount>{it, [] (auto& it) { return it->second; }};
+      return detail::dynamic_iterator<RefCount>{it, [] (auto& it) -> auto const& { return it->second; }};
     } else if (tmp_key.is_integer()) {
       auto& elements = get_elements();
       auto pos = static_cast<size_type>(tmp_key.integer());
       if (pos >= elements.size()) throw std::out_of_range("dart::heap cannot set a value at out of range index");
       auto it = elements.begin() + pos;
       *it = std::forward<decltype(tmp_val)>(tmp_val);
-      return detail::dn_iterator<RefCount> {it, [] (auto& it) { return *it; }};
+      return detail::dynamic_iterator<RefCount> {it, [] (auto& it) -> auto const& { return *it; }};
     } else {
       throw type_error("dart::heap cannot set keys with non string/integer types");
     }
@@ -640,7 +695,7 @@ namespace dart {
   template <class ValueType, class>
   auto basic_heap<RefCount>::set(iterator pos, ValueType&& value) -> iterator {
     // Dig all the way down and get the underlying iterator layout.
-    using elements_layout = typename detail::dn_iterator<RefCount>::elements_layout;
+    using elements_layout = typename detail::dynamic_iterator<RefCount>::elements_layout;
 
     // Make sure our iterator can be used.
     if (!pos) throw std::invalid_argument("dart::heap cannot insert from a valueless iterator");
@@ -686,9 +741,10 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   auto basic_heap<RefCount>::erase(iterator pos) -> iterator {
     // Dig all the way down and get the underlying iterator layout.
-    using fields_layout = typename detail::dn_iterator<RefCount>::fields_layout;
+    using fields_layout = typename detail::dynamic_iterator<RefCount>::fields_layout;
 
     // Make sure our iterator can be used.
     if (!pos) throw std::invalid_argument("dart::heap cannot erase from a valueless iterator");
@@ -709,6 +765,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   auto basic_packet<RefCount>::erase(iterator pos) -> iterator {
     if (!pos) throw std::invalid_argument("dart::packet cannot erase from a valueless iterator");
     auto* it = shim::get_if<typename basic_heap<RefCount>::iterator>(&pos.impl);
@@ -717,6 +774,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   void basic_heap<RefCount>::clear() {
     if (is_object()) get_fields().clear();
     else if (is_array()) get_elements().clear();
@@ -724,6 +782,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   void basic_packet<RefCount>::clear() {
     get_heap().clear();
   }
@@ -739,37 +798,44 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>& basic_heap<RefCount>::definalize() & {
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> const& basic_heap<RefCount>::definalize() const& {
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>&& basic_heap<RefCount>::definalize() && {
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> const&& basic_heap<RefCount>::definalize() const&& {
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_buffer<RefCount>::definalize() const {
     return basic_heap<RefCount> {*this};
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::definalize() & {
     if (is_finalized()) impl = basic_heap<RefCount> {shim::get<basic_buffer<RefCount>>(impl)};
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::definalize() && {
     definalize();
     return std::move(*this);
@@ -786,36 +852,43 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>& basic_heap<RefCount>::lift() & {
     return definalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> const& basic_heap<RefCount>::lift() const& {
     return definalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>&& basic_heap<RefCount>::lift() && {
     return std::move(*this).definalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> const&& basic_heap<RefCount>::lift() const&& {
     return std::move(*this).definalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_buffer<RefCount>::lift() const {
     return definalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::lift() & {
     return definalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::lift() && {
     return std::move(*this).definalize();
   }
@@ -831,37 +904,44 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_heap<RefCount>::finalize() const {
     return basic_buffer<RefCount> {*this};
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>& basic_buffer<RefCount>::finalize() & {
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> const& basic_buffer<RefCount>::finalize() const& {
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::finalize() && {
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> const&& basic_buffer<RefCount>::finalize() const&& {
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::finalize() & {
     if (!is_finalized()) impl = basic_buffer<RefCount> {shim::get<basic_heap<RefCount>>(impl)};
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::finalize() && {
     finalize();
     return std::move(*this);
@@ -878,36 +958,43 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_heap<RefCount>::lower() const {
     return finalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>& basic_buffer<RefCount>::lower() & {
     return finalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> const& basic_buffer<RefCount>::lower() const& {
     return finalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::lower() && {
     return std::move(*this).finalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> const&& basic_buffer<RefCount>::lower() const&& {
     return std::move(*this).finalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::lower() & {
     return finalize();
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::lower() && {
     return std::move(*this).finalize();
   }
@@ -1937,11 +2024,11 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::begin() const -> iterator {
     if (is_object()) {
-      auto deref = [] (auto& it) { return it->second; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_fields()->begin(), deref));
+      auto deref = [] (auto& it) -> auto const& { return it->second; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_fields()->begin(), deref));
     } else if (is_array()) {
-      auto deref = [] (auto& it) { return *it; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_elements()->begin(), deref));
+      auto deref = [] (auto& it) -> auto const& { return *it; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_elements()->begin(), deref));
     } else {
       throw type_error("dart::heap isn't an aggregate and cannot be iterated over");
     }
@@ -1997,11 +2084,11 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::end() const -> iterator {
     if (is_object()) {
-      auto deref = [] (auto& it) { return it->second; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_fields()->end(), deref));
+      auto deref = [] (auto& it) -> auto const& { return it->second; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_fields()->end(), deref));
     } else if (is_array()) {
-      auto deref = [] (auto& it) { return *it; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_elements()->end(), deref));
+      auto deref = [] (auto& it) -> auto const& { return *it; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_elements()->end(), deref));
     } else {
       throw type_error("dart::heap isn't an aggregate and cannot be iterated over");
     }
@@ -2102,8 +2189,8 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::key_begin() const -> iterator {
     if (is_object()) {
-      auto deref = [] (auto& it) { return it->first; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_fields()->begin(), deref));
+      auto deref = [] (auto& it) -> auto const& { return it->first; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_fields()->begin(), deref));
     } else {
       throw type_error("dart::heap is not an object and cannot iterate over keys");
     }
@@ -2147,8 +2234,8 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::key_end() const -> iterator {
     if (is_object()) {
-      auto deref = [] (auto& it) { return it->first; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_fields()->end(), deref));
+      auto deref = [] (auto& it) -> auto const& { return it->first; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_fields()->end(), deref));
     } else {
       throw type_error("dart::heap is not an object and cannot iterate over keys");
     }
@@ -2262,6 +2349,44 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_packet<RefCount>::rkvend() const -> std::tuple<reverse_iterator, reverse_iterator> {
     return std::tuple<reverse_iterator, reverse_iterator> {rkey_end(), rend()};
+  }
+
+  template <template <class> class RefCount>
+  constexpr bool basic_heap<RefCount>::is_view() const noexcept {
+    return !refcount::is_owner<RefCount>::value;
+  }
+
+  template <template <class> class RefCount>
+  constexpr bool basic_buffer<RefCount>::is_view() const noexcept {
+    return !refcount::is_owner<RefCount>::value;
+  }
+
+  template <template <class> class RefCount>
+  constexpr bool basic_packet<RefCount>::is_view() const noexcept {
+    return !refcount::is_owner<RefCount>::value;
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class, class>
+  auto basic_heap<RefCount>::as_owner() const noexcept {
+    return refcount::owner_indirection_t<dart::basic_heap, RefCount> {detail::view_tag {}, data};
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class, class>
+  auto basic_buffer<RefCount>::as_owner() const noexcept {
+    refcount::owner_indirection_t<dart::basic_buffer, RefCount> tmp;
+    tmp.raw = raw;
+    tmp.buffer_ref = buffer_ref.raw().raw();
+    return tmp;
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class, class>
+  auto basic_packet<RefCount>::as_owner() const noexcept {
+    return shim::visit([] (auto& impl) -> refcount::owner_indirection_t<dart::basic_packet, RefCount> {
+      return impl.as_owner();
+    }, impl);
   }
 
   inline namespace literals {

--- a/include/dart/dart_arr.tcc
+++ b/include/dart/dart_arr.tcc
@@ -30,12 +30,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class... Args>
+  template <class... Args, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_array(Args&&... elems) {
     return basic_heap<RefCount>::make_array(std::forward<Args>(elems)...);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_array(gsl::span<basic_heap const> elems) {
     auto arr = basic_heap(detail::array_tag {});
     push_elems<false>(arr, elems);
@@ -43,11 +44,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_array(gsl::span<basic_heap<RefCount> const> elems) {
     return basic_heap<RefCount>::make_array(elems);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_array(gsl::span<basic_buffer<RefCount> const> elems) {
     auto arr = basic_heap(detail::array_tag {});
     push_elems<false>(arr, elems);
@@ -55,11 +58,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_array(gsl::span<basic_buffer<RefCount> const> elems) {
     return basic_heap<RefCount>::make_array(elems);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_array(gsl::span<basic_packet<RefCount> const> elems) {
     auto arr = basic_heap(detail::array_tag {});
     push_elems<false>(arr, elems);
@@ -67,6 +72,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_array(gsl::span<basic_packet<RefCount> const> elems) {
     return basic_heap<RefCount>::make_array(elems);
   }
@@ -122,12 +128,14 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>& basic_heap<RefCount>::pop_front() & {
     erase(0);
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::pop_front() & {
     get_heap().pop_front();
     return *this;
@@ -142,12 +150,14 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>&& basic_heap<RefCount>::pop_front() && {
     pop_front();
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::pop_front() && {
     pop_front();
     return std::move(*this);
@@ -204,12 +214,14 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>& basic_heap<RefCount>::pop_back() & {
     erase(size() - 1);
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::pop_back() & {
     get_heap().pop_back();
     return *this;
@@ -224,12 +236,14 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>&& basic_heap<RefCount>::pop_back() && {
     pop_back();
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::pop_back() && {
     pop_back();
     return std::move(*this);
@@ -254,18 +268,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   auto basic_heap<RefCount>::erase(basic_number<Number> const& idx) -> iterator {
     return erase(idx.integer());
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   auto basic_packet<RefCount>::erase(basic_number<Number> const& idx) -> iterator {
     return erase(idx.integer());
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   auto basic_heap<RefCount>::erase(size_type pos) -> iterator {
     // Make sure we copy out if our heap is shared.
     copy_on_write();
@@ -274,10 +289,11 @@ namespace dart {
     auto& elements = get_elements();
     if (pos >= elements.size()) return end();
     auto new_it = elements.erase(elements.begin() + pos);
-    return detail::dn_iterator<RefCount> {new_it, [] (auto& it) { return *it; }};
+    return detail::dynamic_iterator<RefCount> {new_it, [] (auto& it) -> auto const& { return *it; }};
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   auto basic_packet<RefCount>::erase(size_type pos) -> iterator {
     return get_heap().erase(pos);
   }
@@ -301,6 +317,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   void basic_heap<RefCount>::reserve(size_type count) {
     get_elements().reserve(count);
   }
@@ -312,6 +329,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   void basic_packet<RefCount>::reserve(size_type count) {
     get_heap().reserve(count);
   }
@@ -353,13 +371,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::operator [](basic_number<Number> const& idx) && {
     return std::move(*this)[idx.integer()];
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::operator [](basic_number<Number> const& idx) && {
     return std::move(*this)[idx.integer()];
   }
@@ -380,11 +398,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::operator [](size_type index) && {
     return std::move(*this).get(index);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::operator [](size_type index) && {
     return std::move(*this).get(index);
   }
@@ -414,7 +434,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::get(basic_number<Number> const& idx) && {
     return std::move(*this).get(idx.integer());
   }
@@ -426,7 +446,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::get(basic_number<Number> const& idx) && {
     return std::move(*this).get(idx.integer());
   }
@@ -455,6 +475,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::get(size_type index) && {
     shim::visit([&] (auto& v) { v = std::move(v).get(index); }, impl);
     return std::move(*this);
@@ -517,7 +538,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::at(basic_number<Number> const& idx) && {
     return std::move(*this).at(idx.integer());
   }
@@ -529,7 +550,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class Number>
+  template <class Number, template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::at(basic_number<Number> const& idx) && {
     return std::move(*this).at(idx.integer());
   }
@@ -551,6 +572,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::at(size_type index) && {
     raw = detail::get_array<RefCount>(raw)->at_elem(index);
     if (is_null()) buffer_ref = nullptr;
@@ -558,6 +580,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::at(size_type index) && {
     shim::visit([&] (auto& v) { v = std::move(v).at(index); }, impl);
     return std::move(*this);
@@ -586,17 +609,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  basic_packet<RefCount> basic_packet<RefCount>::at_front() const& {
+    return shim::visit([] (auto& v) -> basic_packet { return v.at_front(); }, impl);
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::at_front() && {
     if (empty()) throw std::out_of_range("dart::buffer is empty and has no value at front");
     else return std::move(*this).front();
   }
 
   template <template <class> class RefCount>
-  basic_packet<RefCount> basic_packet<RefCount>::at_front() const& {
-    return shim::visit([] (auto& v) -> basic_packet { return v.at_front(); }, impl);
-  }
-
-  template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::at_front() && {
     shim::visit([] (auto& v) -> basic_packet { v = std::move(v).at_front(); }, impl);
     return std::move(*this);
@@ -625,17 +650,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  basic_packet<RefCount> basic_packet<RefCount>::at_back() const& {
+    return shim::visit([] (auto& v) -> basic_packet { return v.at_back(); }, impl);
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::at_back() && {
     if (empty()) throw std::out_of_range("dart::buffer is empty and has no value at back");
     else return std::move(*this).back();
   }
 
   template <template <class> class RefCount>
-  basic_packet<RefCount> basic_packet<RefCount>::at_back() const& {
-    return shim::visit([] (auto& v) -> basic_packet { return v.at_back(); }, impl);
-  }
-
-  template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::at_back() && {
     shim::visit([] (auto& v) -> basic_packet { v = std::move(v).at_back(); }, impl);
     return std::move(*this);
@@ -666,6 +693,12 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  basic_packet<RefCount> basic_packet<RefCount>::front() const& {
+    return shim::visit([] (auto& v) -> basic_packet { return v.front(); }, impl);
+  }
+
+  template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::front() && {
     auto* arr = detail::get_array<RefCount>(raw);
     if (empty()) raw = {detail::raw_type::null, nullptr};
@@ -675,11 +708,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  basic_packet<RefCount> basic_packet<RefCount>::front() const& {
-    return shim::visit([] (auto& v) -> basic_packet { return v.front(); }, impl);
-  }
-
-  template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::front() && {
     shim::visit([] (auto& v) { v = std::move(v).front(); }, impl);
     return std::move(*this);
@@ -729,6 +758,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::back() && {
     auto* arr = detail::get_array<RefCount>(raw);
     if (empty()) raw = {detail::raw_type::null, nullptr};
@@ -743,6 +773,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::back() && {
     shim::visit([] (auto& v) { v = std::move(v).back(); }, impl);
     return std::move(*this);
@@ -804,7 +835,7 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::iterator_index(iterator pos) const -> size_type {
     // Dig all the way down and get the underlying iterator layout.
-    using elements_layout = typename detail::dn_iterator<RefCount>::elements_layout;
+    using elements_layout = typename detail::dynamic_iterator<RefCount>::elements_layout;
     return shim::visit(
       shim::compose_together(
         [] (elements_type const& elems, elements_layout& layout) -> size_type {

--- a/include/dart/dart_iterator.tcc
+++ b/include/dart/dart_iterator.tcc
@@ -286,8 +286,8 @@ namespace dart {
     }
 
     template <template <class> class RefCount>
-    auto dn_iterator<RefCount>::operator *() const noexcept -> value_type {
-      return shim::visit([] (auto& impl) { return impl.deref(impl.it); }, impl);
+    auto dn_iterator<RefCount>::operator *() const noexcept -> reference {
+      return shim::visit([] (auto& impl) -> auto& { return impl.deref(impl.it); }, impl);
     }
 
   }

--- a/include/dart/dart_json.tcc
+++ b/include/dart/dart_json.tcc
@@ -73,7 +73,7 @@ namespace dart {
 
 #ifdef DART_USE_SAJSON
   template <template <class> class RefCount>
-  template <unsigned parse_stack_size>
+  template <unsigned parse_stack_size, template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::from_json(shim::string_view json) {
     // Allocate however much stack space was requested.
     std::array<size_t, parse_stack_size / sizeof(size_t)> stack;
@@ -89,7 +89,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <unsigned parse_stack_size>
+  template <unsigned parse_stack_size, template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::from_json(shim::string_view json) {
     // Allocate however much stack space was requested.
     std::array<size_t, parse_stack_size / sizeof(size_t)> stack;
@@ -109,14 +109,14 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <unsigned parse_stack_size>
+  template <unsigned parse_stack_size, template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::from_json(shim::string_view json, bool finalized) {
     if (finalized) return basic_buffer<RefCount>::template from_json<parse_stack_size>(json);
     else return basic_heap<RefCount>::template from_json<parse_stack_size>(json);
   }
 #elif DART_HAS_RAPIDJSON
   template <template <class> class RefCount>
-  template <unsigned flags>
+  template <unsigned flags, template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::from_json(shim::string_view json) {
     // Construct a reader class to parse this string.
     rapidjson::Reader reader;
@@ -141,7 +141,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <unsigned flags>
+  template <unsigned flags, template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::from_json(shim::string_view json) {
     // Duplicate the given string locally so we can use the RapidJSON in-situ parser.
     auto buf = std::make_unique<char[]>(json.size() + 1);
@@ -174,7 +174,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <unsigned flags>
+  template <unsigned flags, template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::from_json(shim::string_view json, bool finalized) {
     if (finalized) return basic_buffer<RefCount>::template from_json<flags>(json);
     else return basic_heap<RefCount>::template from_json<flags>(json);

--- a/include/dart/dart_obj.tcc
+++ b/include/dart/dart_obj.tcc
@@ -119,6 +119,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_object(gsl::span<basic_heap const> pairs) {
     auto obj = basic_heap(detail::object_tag {});
     inject_pairs<false>(obj, pairs);
@@ -126,16 +127,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::make_object(gsl::span<basic_heap<RefCount> const> pairs) {
     return dynamic_make_object(pairs);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_object(gsl::span<basic_heap<RefCount> const> pairs) {
     return basic_heap<RefCount>::make_object(pairs);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_object(gsl::span<basic_buffer<RefCount> const> pairs) {
     auto obj = basic_heap(detail::object_tag {});
     inject_pairs<false>(obj, pairs);
@@ -143,16 +147,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::make_object(gsl::span<basic_buffer const> pairs) {
     return dynamic_make_object(pairs);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_object(gsl::span<basic_buffer<RefCount> const> pairs) {
     return basic_heap<RefCount>::make_object(pairs);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_object(gsl::span<basic_packet<RefCount> const> pairs) {
     auto obj = basic_heap(detail::object_tag {});
     inject_pairs<false>(obj, pairs);
@@ -160,11 +167,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::make_object(gsl::span<basic_packet<RefCount> const> pairs) {
     return dynamic_make_object(pairs);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_object(gsl::span<basic_packet const> pairs) {
     return basic_heap<RefCount>::make_object(pairs);
   }
@@ -213,24 +222,28 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>& basic_heap<RefCount>::remove_field(shim::string_view key) & {
     erase(key);
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>& basic_packet<RefCount>::remove_field(shim::string_view key) & {
     erase(key);
     return *this;
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount>&& basic_heap<RefCount>::remove_field(shim::string_view key) && {
     remove_field(key);
     return std::move(*this);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::remove_field(shim::string_view key) && {
     remove_field(key);
     return std::move(*this);
@@ -298,23 +311,25 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   auto basic_heap<RefCount>::erase(basic_string<String> const& key) -> iterator {
     return erase(key.strv());
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   auto basic_packet<RefCount>::erase(basic_string<String> const& key) -> iterator {
     return erase(key.strv());
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   auto basic_heap<RefCount>::erase(shim::string_view key) -> iterator {
-    return erase_key_impl(key, [] (auto& it) { return it->second; }, nullptr);
+    return erase_key_impl(key, [] (auto& it) -> auto const& { return it->second; }, nullptr);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   auto basic_packet<RefCount>::erase(shim::string_view key) -> iterator {
     return get_heap().erase(key);
   }
@@ -361,6 +376,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::inject(gsl::span<basic_heap const> pairs) const {
     auto obj {*this};
     inject_pairs<false>(obj, pairs);
@@ -368,16 +384,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::inject(gsl::span<basic_heap<RefCount> const> pairs) const {
     return detail::buffer_builder<RefCount>::merge_buffers(*this, make_object(pairs));
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::inject(gsl::span<basic_heap<RefCount> const> pairs) const {
     return shim::visit([&] (auto& v) -> basic_packet { return v.inject(pairs); }, impl);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::inject(gsl::span<basic_buffer<RefCount> const> pairs) const {
     auto obj {*this};
     inject_pairs<false>(obj, pairs);
@@ -385,16 +404,19 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::inject(gsl::span<basic_buffer const> pairs) const {
     return detail::buffer_builder<RefCount>::merge_buffers(*this, make_object(pairs));
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::inject(gsl::span<basic_buffer<RefCount> const> pairs) const {
     return shim::visit([&] (auto& v) -> basic_packet { return v.inject(pairs); }, impl);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::inject(gsl::span<basic_packet<RefCount> const> pairs) const {
     auto obj {*this};
     inject_pairs<false>(obj, pairs);
@@ -402,11 +424,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::inject(gsl::span<basic_packet<RefCount> const> pairs) const {
     return detail::buffer_builder<RefCount>::merge_buffers(*this, make_object(pairs));
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::inject(gsl::span<basic_packet const> pairs) const {
     return shim::visit([&] (auto& v) -> basic_packet { return v.inject(pairs); }, impl);
   }
@@ -423,46 +447,55 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::project(std::initializer_list<shim::string_view> keys) const {
     return project_keys(keys);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::project(std::initializer_list<shim::string_view> keys) const {
     return detail::buffer_builder<RefCount>::project_keys(*this, keys);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::project(std::initializer_list<shim::string_view> keys) const {
     return shim::visit([&] (auto& v) -> basic_packet { return v.project(keys); }, impl);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::project(gsl::span<std::string const> keys) const {
     return project_keys(keys);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::project(gsl::span<std::string const> keys) const {
     return detail::buffer_builder<RefCount>::project_keys(*this, keys);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::project(gsl::span<std::string const> keys) const {
     return shim::visit([&] (auto& v) -> basic_packet { return v.project(keys); }, impl);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::project(gsl::span<shim::string_view const> keys) const {
     return project_keys(keys);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::project(gsl::span<shim::string_view const> keys) const {
     return detail::buffer_builder<RefCount>::project_keys(*this, keys);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::project(gsl::span<shim::string_view const> keys) const {
     return shim::visit([&] (auto& v) -> basic_packet { return v.project(keys); }, impl);
   }
@@ -498,13 +531,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::operator [](basic_string<String> const& key) && {
     return std::move(*this)[key.strv()];
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::operator [](basic_string<String> const& key) && {
     return std::move(*this)[key.strv()];
   }
@@ -525,11 +558,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::operator [](shim::string_view key) && {
     return std::move(*this).get(key);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::operator [](shim::string_view key) && {
     return std::move(*this).get(key);
   }
@@ -559,7 +594,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::get(basic_string<String> const& key) && {
     return std::move(*this).get(key.strv());
   }
@@ -571,7 +606,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::get(basic_string<String> const& key) && {
     return std::move(*this).get(key.strv());
   }
@@ -582,7 +617,8 @@ namespace dart {
     // a temporary heap.
     auto& fields = get_fields();
     auto found = fields.find(key);
-    return found != fields.end() ? found->second : basic_heap::null();
+    if (found == fields.end()) return basic_heap::make_null();
+    else return found->second;
   }
 
   template <template <class> class RefCount>
@@ -596,6 +632,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::get(shim::string_view key) && {
     raw = detail::get_object<RefCount>(raw)->get_value(key);
     if (is_null()) buffer_ref = nullptr;
@@ -603,6 +640,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::get(shim::string_view key) && {
     shim::visit([&] (auto& v) { v = std::move(v).get(key); }, impl);
     return std::move(*this);
@@ -685,7 +723,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::at(basic_string<String> const& key) && {
     return std::move(*this).at(key.strv());
   }
@@ -697,7 +735,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <class String>
+  template <class String, template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::at(basic_string<String> const& key) && {
     return std::move(*this).at(key.strv());
   }
@@ -723,6 +761,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount>&& basic_buffer<RefCount>::at(shim::string_view key) && {
     raw = detail::get_object<RefCount>(raw)->at_value(key);
     if (is_null()) buffer_ref = nullptr;
@@ -730,6 +769,7 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount>&& basic_packet<RefCount>::at(shim::string_view key) && {
     shim::visit([&] (auto& v) { v = std::move(v).at(key); }, impl);
     return std::move(*this);
@@ -762,8 +802,8 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::find(shim::string_view key) const -> iterator {
     if (is_object()) {
-      auto deref = [] (auto& it) { return it->second; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_fields()->find(key), deref));
+      auto deref = [] (auto& it) -> auto const& { return it->second; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_fields()->find(key), deref));
     } else {
       throw type_error("dart::heap isn't an object and cannot find key-value mappings");
     }
@@ -806,8 +846,8 @@ namespace dart {
   template <template <class> class RefCount>
   auto basic_heap<RefCount>::find_key(shim::string_view key) const -> iterator {
     if (is_object()) {
-      auto deref = [] (auto& it) { return it->first; };
-      return iterator(detail::dn_iterator<RefCount>(try_get_fields()->find(key), deref));
+      auto deref = [] (auto& it) -> auto const& { return it->first; };
+      return iterator(detail::dynamic_iterator<RefCount>(try_get_fields()->find(key), deref));
     } else {
       throw type_error("dart::heap isn't an object and cannot find key-value mappings");
     }
@@ -961,12 +1001,12 @@ namespace dart {
 
     // Erase if we found it.
     if (new_it != fields.end()) new_it = fields.erase(new_it);
-    return detail::dn_iterator<RefCount> {new_it, std::forward<Deref>(deref)};
+    return detail::dynamic_iterator<RefCount> {new_it, std::forward<Deref>(deref)};
   }
 
   template <template <class> class RefCount>
   shim::string_view basic_heap<RefCount>::iterator_key(iterator pos) const {
-    using fields_layout = typename detail::dn_iterator<RefCount>::fields_layout;
+    using fields_layout = typename detail::dynamic_iterator<RefCount>::fields_layout;
     return shim::visit(
       shim::compose_together(
         [] (fields_type const&, fields_layout& layout) -> shim::string_view {

--- a/include/dart/dart_operators.tcc
+++ b/include/dart/dart_operators.tcc
@@ -15,58 +15,38 @@ namespace dart {
   /*----- Wrapper Equality Operations -----*/
 
   // Macro defines symmetric equality comparison operators (across implementation types)
-  // for a given wrapper template
-#define DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(wrapper)                                                         \
-  template <template <class> class RefCount,                                                                    \
-           template <template <class> class> class LhsPacket,                                                   \
-           template <template <class> class> class RhsPacket>                                                   \
-  bool operator ==(wrapper<LhsPacket<RefCount>> const& lhs, wrapper<RhsPacket<RefCount>> const& rhs) {          \
-    return lhs.dynamic() == rhs.dynamic();                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount,                                                                    \
-           template <template <class> class> class LhsPacket,                                                   \
-           template <template <class> class> class RhsPacket>                                                   \
-  bool operator !=(wrapper<LhsPacket<RefCount>> const& lhs, wrapper<RhsPacket<RefCount>> const& rhs) {          \
-    return !(lhs == rhs);                                                                                       \
-  }
-
-  DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(basic_object);
-  DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(basic_array);
-  DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(basic_string);
-  DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(basic_number);
-  DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(basic_flag);
-  DART_DEFINE_WRAPPER_EQUALITY_OPERATORS(basic_null);
-#undef DART_DEFINE_WRAPPER_EQUALITY_OPERATORS
-
-  // Macro defines symmetric equality comparison operators (across implementation types)
   // for a given pair of wrapper templates.
 #define DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(lhs_wrapper, rhs_wrapper)                                  \
-  template <template <class> class RefCount,                                                                    \
-           template <template <class> class> class LhsPacket,                                                   \
-           template <template <class> class> class RhsPacket>                                                   \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC,                                                                       \
+            template <template <class> class> class LhsPacket,                                                  \
+            template <template <class> class> class RhsPacket>                                                  \
   constexpr bool                                                                                                \
-  operator ==(lhs_wrapper<LhsPacket<RefCount>> const&, rhs_wrapper<RhsPacket<RefCount>> const&) {               \
+  operator ==(lhs_wrapper<LhsPacket<LhsRC>> const&, rhs_wrapper<RhsPacket<RhsRC>> const&) {                     \
     return false;                                                                                               \
   }                                                                                                             \
-  template <template <class> class RefCount,                                                                    \
-           template <template <class> class> class LhsPacket,                                                   \
-           template <template <class> class> class RhsPacket>                                                   \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC,                                                                       \
+            template <template <class> class> class LhsPacket,                                                  \
+            template <template <class> class> class RhsPacket>                                                  \
   constexpr bool                                                                                                \
-  operator !=(lhs_wrapper<LhsPacket<RefCount>> const& lhs, rhs_wrapper<RhsPacket<RefCount>> const& rhs) {       \
+  operator !=(lhs_wrapper<LhsPacket<LhsRC>> const& lhs, rhs_wrapper<RhsPacket<RhsRC>> const& rhs) {             \
     return !(lhs == rhs);                                                                                       \
   }                                                                                                             \
-  template <template <class> class RefCount,                                                                    \
-           template <template <class> class> class LhsPacket,                                                   \
-           template <template <class> class> class RhsPacket>                                                   \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC,                                                                       \
+            template <template <class> class> class LhsPacket,                                                  \
+            template <template <class> class> class RhsPacket>                                                  \
   constexpr bool                                                                                                \
-  operator ==(rhs_wrapper<LhsPacket<RefCount>> const&, lhs_wrapper<RhsPacket<RefCount>> const&) {               \
+  operator ==(rhs_wrapper<LhsPacket<LhsRC>> const&, lhs_wrapper<RhsPacket<RhsRC>> const&) {                     \
     return false;                                                                                               \
   }                                                                                                             \
-  template <template <class> class RefCount,                                                                    \
-           template <template <class> class> class LhsPacket,                                                   \
-           template <template <class> class> class RhsPacket>                                                   \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC,                                                                       \
+            template <template <class> class> class LhsPacket,                                                  \
+            template <template <class> class> class RhsPacket>                                                  \
   constexpr bool                                                                                                \
-  operator !=(rhs_wrapper<LhsPacket<RefCount>> const& rhs, lhs_wrapper<RhsPacket<RefCount>> const& lhs) {       \
+  operator !=(rhs_wrapper<LhsPacket<LhsRC>> const& rhs, lhs_wrapper<RhsPacket<RhsRC>> const& lhs) {             \
     return !(rhs == lhs);                                                                                       \
   }
 
@@ -96,20 +76,24 @@ namespace dart {
   // XXX: Would be nice to be able to compare across packet types here, but these templates
   // aren't otherwise constrained, and I'm afraid it would be too wide open.
 #define DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(wrapper)                                                  \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator ==(wrapper<Packet<RefCount>> const& lhs, Packet<RefCount> const& rhs) {                         \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC, template <template <class> class> class Packet>                       \
+  bool operator ==(wrapper<Packet<LhsRC>> const& lhs, Packet<RhsRC> const& rhs) {                               \
     return lhs.dynamic() == rhs;                                                                                \
   }                                                                                                             \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator !=(wrapper<Packet<RefCount>> const& lhs, Packet<RefCount> const& rhs) {                         \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC, template <template <class> class> class Packet>                       \
+  bool operator !=(wrapper<Packet<LhsRC>> const& lhs, Packet<RhsRC> const& rhs) {                               \
     return !(lhs == rhs);                                                                                       \
   }                                                                                                             \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator ==(Packet<RefCount> const& rhs, wrapper<Packet<RefCount>> const& lhs) {                         \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC, template <template <class> class> class Packet>                       \
+  bool operator ==(Packet<LhsRC> const& rhs, wrapper<Packet<RhsRC>> const& lhs) {                               \
     return rhs == lhs.dynamic();                                                                                \
   }                                                                                                             \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator !=(Packet<RefCount> const& rhs, wrapper<Packet<RefCount>> const& lhs) {                         \
+  template <template <class> class LhsRC,                                                                       \
+            template <class> class RhsRC, template <template <class> class> class Packet>                       \
+  bool operator !=(Packet<LhsRC> const& rhs, wrapper<Packet<RhsRC>> const& lhs) {                               \
     return !(rhs == lhs);                                                                                       \
   }
 
@@ -168,8 +152,8 @@ namespace dart {
 
   /*----- Cross-type Equality Operators -----*/
 
-  template <template <class> class RefCount>
-  bool operator ==(basic_buffer<RefCount> const& lhs, basic_heap<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator ==(basic_buffer<LhsRC> const& lhs, basic_heap<RhsRC> const& rhs) {
     // Make sure they're at least of the same type.
     if (lhs.get_type() != rhs.get_type()) return false;
 
@@ -183,7 +167,7 @@ namespace dart {
           // Ouch.
           // Iterates over rhs and looks up into lhs because lhs is the finalized
           // object and lookups should be significantly faster on it.
-          typename basic_heap<RefCount>::iterator k, v;
+          typename basic_heap<RhsRC>::iterator k, v;
           std::tie(k, v) = rhs.kvbegin();
           while (v != rhs.end()) {
             if (*v != lhs[*k]) return false;
@@ -216,38 +200,38 @@ namespace dart {
     }
   }
 
-  template <template <class> class RefCount>
-  bool operator ==(basic_heap<RefCount> const& lhs, basic_buffer<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator ==(basic_heap<LhsRC> const& lhs, basic_buffer<RhsRC> const& rhs) {
     return rhs == lhs;
   }
 
-  template <template <class> class RefCount>
-  bool operator ==(basic_buffer<RefCount> const& lhs, basic_packet<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator ==(basic_buffer<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
     return shim::visit([&] (auto& v) { return lhs == v; }, rhs.impl);
   }
 
-  template <template <class> class RefCount>
-  bool operator ==(basic_heap<RefCount> const& lhs, basic_packet<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator ==(basic_heap<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
     return shim::visit([&] (auto& v) { return lhs == v; }, rhs.impl);
   }
 
-  template <template <class> class RefCount>
-  bool operator !=(basic_buffer<RefCount> const& lhs, basic_heap<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator !=(basic_buffer<LhsRC> const& lhs, basic_heap<RhsRC> const& rhs) {
     return !(lhs == rhs);
   }
 
-  template <template <class> class RefCount>
-  bool operator !=(basic_heap<RefCount> const& lhs, basic_buffer<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator !=(basic_heap<LhsRC> const& lhs, basic_buffer<RhsRC> const& rhs) {
     return !(lhs == rhs);
   }
 
-  template <template <class> class RefCount>
-  bool operator !=(basic_buffer<RefCount> const& lhs, basic_packet<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator !=(basic_buffer<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
     return !(lhs == rhs);
   }
 
-  template <template <class> class RefCount>
-  bool operator !=(basic_heap<RefCount> const& lhs, basic_packet<RefCount> const& rhs) {
+  template <template <class> class LhsRC, template <class> class RhsRC>
+  bool operator !=(basic_heap<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
     return !(lhs == rhs);
   }
 

--- a/include/dart/dart_primitive.tcc
+++ b/include/dart/dart_primitive.tcc
@@ -28,31 +28,37 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_integer(int64_t val) noexcept {
     return basic_heap(detail::integer_tag {}, val);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_integer(int64_t val) noexcept {
     return basic_heap<RefCount>::make_integer(val);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_decimal(double val) noexcept {
     return basic_heap(detail::decimal_tag {}, val);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_decimal(double val) noexcept {
     return basic_heap<RefCount>::make_decimal(val);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_boolean(bool val) noexcept {
     return basic_heap(detail::boolean_tag {}, val);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_boolean(bool val) noexcept {
     return basic_heap<RefCount>::make_boolean(val);
   }

--- a/include/dart/dart_shim.h
+++ b/include/dart/dart_shim.h
@@ -69,6 +69,8 @@ namespace dart {
     using std::get_if;
     using std::launder;
     using std::holds_alternative;
+    using std::variant_alternative;
+    using std::variant_alternative_t;
 
     // Define a way to compose lambdas.
     template <class... Ls>
@@ -95,6 +97,8 @@ namespace dart {
     using mpark::visit;
     using mpark::get_if;
     using mpark::holds_alternative;
+    using mpark::variant_alternative;
+    using mpark::variant_alternative_t;
 
     // Pull in constants.
     static constexpr auto nullopt = dart::nullopt;

--- a/include/dart/dart_str.tcc
+++ b/include/dart/dart_str.tcc
@@ -17,11 +17,13 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::make_string(shim::string_view val) {
     return basic_heap(detail::string_tag {}, val);
   }
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::make_string(shim::string_view val) {
     return basic_heap<RefCount>::make_string(val);
   }

--- a/include/dart/dart_yaml.tcc
+++ b/include/dart/dart_yaml.tcc
@@ -35,16 +35,19 @@ namespace dart {
   };
 
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_heap<RefCount> basic_heap<RefCount>::from_yaml(shim::string_view yaml) {
     return detail::parse_yaml<RefCount>(yaml);
   }
   
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_buffer<RefCount> basic_buffer<RefCount>::from_yaml(shim::string_view yaml) {
     return basic_buffer {detail::parse_yaml<RefCount>(yaml)};
   }
   
   template <template <class> class RefCount>
+  template <template <class> class, class>
   basic_packet<RefCount> basic_packet<RefCount>::from_yaml(shim::string_view yaml, bool finalized) {
     auto tmp = basic_heap<RefCount>::from_yaml(yaml);
     if (finalized) return basic_buffer<RefCount> {std::move(tmp)};

--- a/include/dart/ptrs.tcc
+++ b/include/dart/ptrs.tcc
@@ -426,11 +426,177 @@ namespace dart {
     refcount_traits<T>::move(&ptr, std::move(impl));
   }
 
+  template <class T>
+  auto shareable_ptr<T>::raw() noexcept -> value_type& {
+    return impl;
+  }
+
+  template <class T>
+  auto shareable_ptr<T>::raw() const noexcept -> value_type const& {
+    return impl;
+  }
+
   template <class T, class... Args>
   shareable_ptr<T> make_shareable(Args&&... the_args) {
     shareable_ptr<T> ptr(typename shareable_ptr<T>::partial_construction_tag {});
     refcount_traits<T>::construct(&ptr.impl, std::forward<Args>(the_args)...);
     return ptr;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  view_ptr_context<RefCount>::view_ptr<T>::view_ptr(T*) {
+    throw std::logic_error("dart::view_ptr cannot be passed an owning raw pointer");
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  template <class Del>
+  view_ptr_context<RefCount>::view_ptr<T>::view_ptr(T*, Del&&) {
+    throw std::logic_error("dart::view_ptr cannot be passed an owning raw pointer");
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  view_ptr_context<RefCount>::view_ptr<T>::view_ptr(view_ptr&& other) noexcept : impl(other.impl) {
+    // XXX: I don't know if this is the right call or not, since view_ptr doesn't generally have
+    // memory ownership semantics, but I figure it's the least surprising thing.
+    other.impl = nullptr;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  auto view_ptr_context<RefCount>::view_ptr<T>::operator =(refcount_type const& owner) noexcept -> view_ptr& {
+    if (impl == &owner) return *this;
+    this->~view_ptr();
+    new(this) view_ptr(owner);
+    return *this;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  auto view_ptr_context<RefCount>::view_ptr<T>::operator =(view_ptr&& other) noexcept -> view_ptr& {
+    if (this == &other) return *this;
+    this->~view_ptr();
+    new(this) view_ptr(std::move(other));
+    return *this;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  auto view_ptr_context<RefCount>::view_ptr<T>::operator *() const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+    -> element_type&
+  {
+    return *get();
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  auto view_ptr_context<RefCount>::view_ptr<T>::operator ->() const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+    -> element_type*
+  {
+    return get();
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  bool view_ptr_context<RefCount>::view_ptr<T>::operator ==(view_ptr const& other) const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return get() == other.get();
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  bool view_ptr_context<RefCount>::view_ptr<T>::operator !=(view_ptr const& other) const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return !(*this == other);
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  bool view_ptr_context<RefCount>::view_ptr<T>::operator <(view_ptr const& other) const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return get() < other.get();
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  bool view_ptr_context<RefCount>::view_ptr<T>::operator <=(view_ptr const& other) const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return !(other < *this);
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  bool view_ptr_context<RefCount>::view_ptr<T>::operator >(view_ptr const& other) const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return other < *this;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  bool view_ptr_context<RefCount>::view_ptr<T>::operator >=(view_ptr const& other) const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return !(*this < other);
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  view_ptr_context<RefCount>::view_ptr<T>::operator bool() const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+  {
+    return get() != nullptr;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  view_ptr_context<RefCount>::view_ptr<T>::operator refcount_type() const {
+    return raw();
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  auto view_ptr_context<RefCount>::view_ptr<T>::get() const
+    noexcept(refcount_traits<refcount_type>::is_nothrow_unwrappable::value)
+    -> element_type*
+  {
+    if (impl) return refcount_traits<RefCount<T>>::unwrap(*impl);
+    else return nullptr;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  size_t view_ptr_context<RefCount>::view_ptr<T>::use_count() const
+    noexcept(refcount_traits<refcount_type>::has_nothrow_use_count::value)
+  {
+    // XXX: view_ptr doesn't have any memory ownership semantics, and so layers
+    // above it should assume it always has at least one unless it's in the null state
+    if (impl) {
+      auto count = refcount_traits<RefCount<T>>::use_count(*impl);
+      return count ? count : 1;
+    } else {
+      return 0;
+    }
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  void view_ptr_context<RefCount>::view_ptr<T>::reset() noexcept {
+    impl = nullptr;
+  }
+
+  template <template <class> class RefCount>
+  template <class T>
+  auto view_ptr_context<RefCount>::view_ptr<T>::raw() const noexcept -> refcount_type const& {
+    return *impl;
   }
 
   template <class T, class>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(catch OBJECT catch_driver.cc)
 
 # Setup targets for our unit tests.
-add_executable(unit_tests type_unit_tests.cc obj_unit_tests.cc arr_unit_tests.cc str_unit_tests.cc int_unit_tests.cc dcm_unit_tests.cc bool_unit_tests.cc null_unit_tests.cc iteration_unit_tests.cc ptr_unit_tests.cc misc_unit_tests.cc optional_unit_tests.cc string_view_unit_tests.cc $<TARGET_OBJECTS:catch>)
+add_executable(unit_tests type_unit_tests.cc obj_unit_tests.cc arr_unit_tests.cc str_unit_tests.cc int_unit_tests.cc dcm_unit_tests.cc bool_unit_tests.cc null_unit_tests.cc iteration_unit_tests.cc ptr_unit_tests.cc misc_unit_tests.cc optional_unit_tests.cc string_view_unit_tests.cc view_unit_tests.cc $<TARGET_OBJECTS:catch>)
 if (build_abi)
   add_executable(abi_tests abi_unit_tests.cc $<TARGET_OBJECTS:catch>)
   target_link_libraries(abi_tests dart_abi)

--- a/test/obj_unit_tests.cc
+++ b/test/obj_unit_tests.cc
@@ -181,7 +181,7 @@ SCENARIO("finalized objects can be deep copied", "[object unit]") {
       DYNAMIC_WHEN("the underlying buffer is copied", idx) {
         auto buf = obj.dup_bytes();
         DYNAMIC_THEN("a new packet can be initialized from it", idx) {
-          pkt copy(std::move(obj));
+          pkt copy(std::move(buf));
         }
       }
     });

--- a/test/view_unit_tests.cc
+++ b/test/view_unit_tests.cc
@@ -1,0 +1,393 @@
+/*----- System Includes -----*/
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <unordered_set>
+#include <unordered_map>
+
+/*----- Local Includes -----*/
+
+#include "dart_tests.h"
+
+/*----- Function Implementations -----*/
+
+SCENARIO("views can be created", "[view unit]") {
+  GIVEN("an object") {
+    dart::api_test([] (auto tag, auto) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      // Get an object.
+      auto obj = pkt::make_object();
+      view obj_view = obj;
+
+      // Check to make sure the type agrees.
+      REQUIRE(obj_view.is_object());
+      REQUIRE(obj_view.get_type() == dart::packet::type::object);
+
+      // Check to make sure the object is empty.
+      REQUIRE(obj_view.size() == 0ULL);
+    });
+  }
+}
+
+SCENARIO("views can be copied", "[view unit]") {
+  GIVEN("an object with some fields") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      // Get an object.
+      auto obj = pkt::make_object("nested", pkt::make_object("hello", "world"));
+      view obj_view = obj;
+
+      // Check the initial refcount.
+      REQUIRE(obj.refcount() == 1);
+      REQUIRE(obj_view.refcount() == 1);
+
+      DYNAMIC_WHEN("the view is copied", idx) {
+        auto copy = obj_view;
+        DYNAMIC_THEN("its reference count does not change", idx) {
+          REQUIRE(obj_view.refcount() == 1U);
+          REQUIRE(copy.refcount() == 1U);
+        }
+      }
+
+      DYNAMIC_WHEN("a field is copied", idx) {
+        auto nested = obj_view["nested"];
+        DYNAMIC_THEN("reference counts do not change", idx) {
+          REQUIRE(obj_view.refcount() == 1U);
+          REQUIRE(nested.refcount() == 1U);
+          REQUIRE(nested["hello"].refcount() == 1U);
+        }
+      }
+
+      DYNAMIC_WHEN("a field is copied from the copy", idx) {
+        auto copy = obj_view;
+        auto nested = copy["nested"];
+        DYNAMIC_THEN("reference counts do not change", idx) {
+          REQUIRE(copy["nested"].refcount() == 1U);
+          REQUIRE(nested.refcount() == 1U);
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("views can be moved", "[view unit]") {
+  GIVEN("an object with some fields") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      // Get an object.
+      auto obj = pkt::make_object("nested", pkt::make_object("hello", "world"));
+      view obj_view = obj;
+
+      // Check the initial refcount.
+      REQUIRE(obj.refcount() == 1ULL);
+      REQUIRE(obj_view.refcount() == 1ULL);
+
+      DYNAMIC_WHEN("the object is moved", idx) {
+        auto new_obj = std::move(obj_view);
+        DYNAMIC_THEN("its reference count does not change", idx) {
+          REQUIRE(obj_view.refcount() == 0ULL);
+          REQUIRE(new_obj.refcount() == 1ULL);
+          REQUIRE(obj_view.get_type() == pkt::type::null);
+          REQUIRE(new_obj.get_type() == pkt::type::object);
+        }
+      }
+
+      DYNAMIC_WHEN("a field is moved", idx) {
+        auto nested = obj_view["nested"];
+        auto new_nested = std::move(nested);
+        DYNAMIC_THEN("the reference count for the field does not change", idx) {
+          REQUIRE(nested.refcount() == 0ULL);
+          REQUIRE(new_nested.refcount() == 1ULL);
+          REQUIRE(nested.get_type() == pkt::type::null);
+          REQUIRE(new_nested.get_type() == pkt::type::object);
+        }
+      }
+
+    });
+  }
+}
+
+SCENARIO("finalized views can be deep copied", "[view unit]") {
+  GIVEN("a finalized object with some contents") {
+    dart::finalized_api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj = pkt::make_object("hello", "world!").finalize();
+      view obj_view = obj;
+      DYNAMIC_WHEN("the underlying buffer is copied", idx) {
+        auto buf = obj_view.dup_bytes();
+        DYNAMIC_THEN("a new packet can be initialized from it", idx) {
+          pkt copy(std::move(buf));
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("views can be compared for equality", "[view unit]") {
+  GIVEN("two empty objects") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj_one = pkt::make_object(), obj_two = pkt::make_object();
+      view view_one = obj_one, view_two = obj_two;
+      DYNAMIC_WHEN("an object is compared against itself", idx) {
+        DYNAMIC_THEN("it compares equal", idx) {
+          REQUIRE(view_one == view_one);
+        }
+      }
+
+      DYNAMIC_WHEN("two disparate objects are compared", idx) {
+        DYNAMIC_THEN("they still compare equal", idx) {
+          REQUIRE(view_one == view_two);
+        }
+      }
+
+      DYNAMIC_WHEN("one object is assigned to the other", idx) {
+        view_two = view_one;
+        DYNAMIC_THEN("they compare equal", idx) {
+          REQUIRE(obj_one == obj_two);
+        }
+      }
+    });
+  }
+
+  GIVEN("two objects with simple, but identical contents") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj_one = pkt::make_object("hello", "world", "one", 1, "two", 2.0, "true", true);
+      auto obj_two = pkt::make_object("hello", "world", "one", 1, "two", 2.0, "true", true);
+      view view_one = obj_one, view_two = obj_two;
+      DYNAMIC_WHEN("they are compared", idx) {
+        DYNAMIC_THEN("they compare equal", idx) {
+          REQUIRE(view_one == view_two);
+        }
+      }
+    });
+  }
+
+  GIVEN("two objects with simple, but different contents") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj_one = pkt::make_object("hello", "life", "one", 1, "two", 2.0, "true", true);
+      auto obj_two = pkt::make_object("hello", "world", "one", 1, "two", 2.0, "true", true);
+      view view_one = obj_one, view_two = obj_two;
+
+      DYNAMIC_WHEN("they are compared", idx) {
+        DYNAMIC_THEN("they do not compare equal", idx) {
+          REQUIRE(view_one != view_two);
+        }
+      }
+    });
+  }
+
+  GIVEN("two objects with nested objects") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj_one = pkt::make_object("obj", pkt::make_object("yes", "no"), "pi", 3.14159);
+      auto obj_two = pkt::make_object("obj", pkt::make_object("yes", "no"), "pi", 3.14159);
+      view view_one = obj_one, view_two = obj_two;
+
+      DYNAMIC_WHEN("they are compared", idx) {
+        DYNAMIC_THEN("they compare equal", idx) {
+          REQUIRE(view_one == view_two);
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("views contextually convert to true", "[view unit]") {
+  GIVEN("an object with some contents") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj = pkt::make_object("hello", "goodbye");
+      view obj_view = obj;
+      DYNAMIC_WHEN("the object is converted to a boolean", idx) {
+        auto valid = static_cast<bool>(obj_view);
+        DYNAMIC_THEN("it converts to true", idx) {
+          REQUIRE(valid);
+        }
+      }
+
+      DYNAMIC_WHEN("a field is converted to a boolean", idx) {
+        auto valid = static_cast<bool>(obj_view["hello"]);
+        DYNAMIC_THEN("it converts to true", idx) {
+          REQUIRE(valid);
+        }
+      }
+
+      DYNAMIC_WHEN("a non-existent field is converted to a boolean", idx) {
+        auto valid = static_cast<bool>(obj_view["nope"]);
+        DYNAMIC_THEN("it converts to false", idx) {
+          REQUIRE_FALSE(valid);
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("finalized views always return buffers for the current object", "[view unit]") {
+  GIVEN("an object with some contents") {
+    dart::finalized_api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj = pkt::make_object("nested", pkt::make_object("data", "value")).finalize();
+      view obj_view = obj;
+      DYNAMIC_WHEN("a nested object is accessed", idx) {
+        auto nested = obj_view["nested"];
+        DYNAMIC_THEN("it returns its own network buffer", idx) {
+          pkt dup {nested.get_bytes()};
+          view dup_view = dup;
+          REQUIRE(dup_view == nested);
+          REQUIRE(dup_view["data"] == nested["data"]);
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("object views cannot be used as an array", "[view unit]") {
+  GIVEN("an object") {
+    dart::mutable_api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto obj = pkt::make_object();
+      view obj_view = obj;
+      DYNAMIC_WHEN("using that object as an array", idx) {
+        DYNAMIC_THEN("it refuses to do so", idx) {
+          REQUIRE_THROWS_AS(obj_view.back(), std::logic_error);
+          REQUIRE_THROWS_AS(obj_view[0], std::logic_error);
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("object views can access nested keys in one step", "[view unit]") {
+  GIVEN("an object with nested fields") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      // Get some data to work on.
+      auto nested = pkt::make_object("time", "dark side", "come_together", "abbey road");
+      auto obj = pkt::make_object("songs", std::move(nested));
+      view obj_view = obj;
+
+      DYNAMIC_WHEN("accessing a valid nested field", idx) {
+        auto dark_side = obj_view.get_nested("songs.time");
+        auto abbey_road = obj_view.get_nested("songs.come_together");
+        DYNAMIC_THEN("it returns the correct value", idx) {
+          REQUIRE(dark_side == "dark side");
+          REQUIRE(abbey_road == "abbey road");
+        }
+      }
+
+      DYNAMIC_WHEN("accessing an invalid path", idx) {
+        auto nested = obj_view.get_nested("songs.not_here");
+        auto bad_nested = obj_view.get_nested(".songs..definitely_not_here.");
+        DYNAMIC_THEN("it returns null", idx) {
+          REQUIRE(nested.is_null());
+          REQUIRE(bad_nested.is_null());
+        }
+      }
+
+      DYNAMIC_WHEN("accessing a path prefix", idx) {
+        auto nested = obj_view.get_nested("song");
+        DYNAMIC_THEN("it returns null", idx) {
+          REQUIRE(nested.is_null());
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("object views can check membership for keys", "[view unit]") {
+  GIVEN("a set of keys and an object with those keys") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      auto tmp = dart::heap::make_object();
+      std::vector<std::string> keys = {"pi", "e", "avogadro", "c"};
+      std::vector<double> values = {3.14159, 2.71828, 6.02214, 2.99792};
+      for (size_t i = 0; i < keys.size(); i++) tmp.add_field(keys[i], values[i]);
+
+      auto obj = dart::conversion_helper<pkt>(tmp);
+      view obj_view = obj;
+      DYNAMIC_WHEN("checking for keys known to exist", idx) {
+        DYNAMIC_THEN("they're reported as being present", idx) {
+          for (auto& key : keys) REQUIRE(obj_view.has_key(key));
+        }
+      }
+
+      DYNAMIC_WHEN("checking for keys that don't exist", idx) {
+        DYNAMIC_THEN("they're reported as absent", idx) {
+          REQUIRE_FALSE(obj_view.has_key("nope"));
+        }
+      }
+
+      DYNAMIC_WHEN("asking directly for the keys the object maintains", idx) {
+        auto direct_keys = obj_view.keys();
+        DYNAMIC_THEN("they're all reported as present", idx) {
+          for (auto& key : direct_keys) REQUIRE(obj_view.has_key(key));
+        }
+      }
+    });
+  }
+}
+
+SCENARIO("object views can export all current values", "[view unit]") {
+  GIVEN("an object with some values") {
+    dart::api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using view = typename pkt::view;
+
+      std::vector<std::string> orig_keys = {"hello", "goodbye", "yes", "no"};
+      std::vector<std::string> orig_vals = {"stop", "go", "yellow", "submarine"};
+      auto tmp = dart::heap::make_object("boolean", true, "null", dart::heap::null());
+      for (size_t i = 0; i < orig_keys.size(); i++) tmp.add_field(orig_keys[i], orig_vals[i]);
+
+      auto obj = dart::conversion_helper<pkt>(tmp);
+      view obj_view = obj;
+      DYNAMIC_WHEN("requesting all currently held values", idx) {
+        auto values = obj_view.values();
+        DYNAMIC_THEN("it returns the full set", idx) {
+          REQUIRE(values.size() == orig_vals.size() + 2);
+
+          for (auto const& val : values) {
+            if (val.is_str()) {
+              std::string value(val.str());
+              REQUIRE(std::find(orig_vals.begin(), orig_vals.end(), value) != orig_vals.end());
+            } else if (val.is_boolean()) {
+              REQUIRE(val.boolean());
+            } else {
+              REQUIRE(val.get_type() == dart::packet::type::null);
+            }
+          }
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
To allow fine-grained discarding of reference counting when desired
Also enabled comparison of Dart types across reference counters