### PR TITLE
Patching bug that converted large ints to doubles

### DIFF
--- a/include/dart/common.h
+++ b/include/dart/common.h
@@ -1347,7 +1347,7 @@ namespace dart {
           return identify_string<RefCount>({curr_val.GetString(), curr_val.GetStringLength()});
         case rapidjson::kNumberType:
           // Figure out what type of number we've been given.
-          if (curr_val.IsInt()) return identify_integer(curr_val.GetInt64());
+          if (curr_val.IsInt64()) return identify_integer(curr_val.GetInt64());
           else return identify_decimal(curr_val.GetDouble());
         case rapidjson::kTrueType:
         case rapidjson::kFalseType:


### PR DESCRIPTION
When an int was larger than 2^31 - 1, Dart was parsing it as a double
This behavior is unavoidable when using the sajson parser, but the
rapidjson parser will now preserve 64 bit ints correctly