### PR TITLE
Generic construction, assignment, and comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,18 @@ int main() {
   std::cout << arr << std::endl;
 
   // A more complex example with some complex STL types.
-  using value = std::variant<double, std::string>;
+  using clock = std::chrono::system_clock;
+  using value = std::variant<double, std::string, clock::time_point>;
   using sequence = std::vector<value>;
   using map = std::map<std::string, sequence>;
 
   // Dart recursively decomposes the type and figures it out.
-  arr.push_back(map {{"args", {3.14159, 2.99792, "top", "secret"}}});
+  arr.push_back(map {{"args", {3.14159, 2.99792, "top", "secret", clock::now()}}});
   std::cout << arr << std::endl;
 }
 
 // => [1,"two",3.14159,true,null]
-// => [1,"two",3.14159,true,null,{"args":[3.14159,2.99792,"top","secret"]}]
+// => [1,"two",3.14159,true,null,{"args":[3.14159,2.99792,"top","secret","2020-02-25T10:58:37Z"]}]
 ```
 
 The **Dart** container types (`dart::object` and `dart::array`) model the API
@@ -301,8 +302,12 @@ namespace dart::convert {
   template <>
   struct to_dart<my_string> {
     template <class Packet>
-    static Packet cast(my_string const& s) {
+    Packet cast(my_string const& s) {
       return Packet::make_string(s.str);
+    }
+    template <class Packet>
+    bool compare(Packet const& pkt, my_string const& s) {
+      return pkt.is_str() && pkt.strv() == s.str;
     }
   };
 }

--- a/include/dart/api.tcc
+++ b/include/dart/api.tcc
@@ -14,75 +14,85 @@
 namespace dart {
 
   template <class Object>
-  template <class OtherObject>
-  bool basic_object<Object>::operator ==(basic_object<OtherObject> const& other) const noexcept {
-    return val == other.val;
-  }
-
-  template <class Array>
-  template <class OtherArray>
-  bool basic_array<Array>::operator ==(basic_array<OtherArray> const& other) const noexcept {
-    return val == other.val;
-  }
-
-  template <class String>
-  template <class OtherString>
-  bool basic_string<String>::operator ==(basic_string<OtherString> const& other) const noexcept {
-    return val == other.val;
-  }
-
-  template <class Number>
-  template <class OtherNumber>
-  bool basic_number<Number>::operator ==(basic_number<OtherNumber> const& other) const noexcept {
-    return val == other.val;
-  }
-
-  template <class Boolean>
-  template <class OtherBoolean>
-  bool basic_flag<Boolean>::operator ==(basic_flag<OtherBoolean> const& other) const noexcept {
-    return val == other.val;
-  }
-
-  template <class Null>
-  template <class OtherNull>
-  constexpr bool basic_null<Null>::operator ==(basic_null<OtherNull> const&) const noexcept {
-    return true;
+  template <class Key, class Value, class Comp, class Alloc, class EnableIf>
+  basic_object<Object>& basic_object<Object>::operator =(std::map<Key, Value, Comp, Alloc> const& map) & {
+    val = convert::cast<value_type>(map);
+    return *this;
   }
 
   template <class Object>
-  template <class OtherObject>
-  bool basic_object<Object>::operator !=(basic_object<OtherObject> const& other) const noexcept {
-    return !(*this == other);
+  template <class Key, class Value, class Comp, class Alloc, class EnableIf>
+  basic_object<Object>& basic_object<Object>::operator =(std::map<Key, Value, Comp, Alloc>&& map) & {
+    val = convert::cast<value_type>(std::move(map));
+    return *this;
+  }
+
+  template <class Object>
+  template <class Key, class Value, class Hash, class Equal, class Alloc, class EnableIf>
+  basic_object<Object>& basic_object<Object>::operator =(std::unordered_map<Key, Value, Hash, Equal, Alloc> const& map) & {
+    val = convert::cast<value_type>(map);
+    return *this;
+  }
+
+  template <class Object>
+  template <class Key, class Value, class Hash, class Equal, class Alloc, class EnableIf>
+  basic_object<Object>& basic_object<Object>::operator =(std::unordered_map<Key, Value, Hash, Equal, Alloc>&& map) & {
+    val = convert::cast<value_type>(std::move(map));
+    return *this;
   }
 
   template <class Array>
-  template <class OtherArray>
-  bool basic_array<Array>::operator !=(basic_array<OtherArray> const& other) const noexcept {
-    return !(*this == other);
+  template <class T, class Alloc, class EnableIf>
+  basic_array<Array>& basic_array<Array>::operator =(std::vector<T, Alloc> const& vec) & {
+    val = convert::cast<value_type>(vec);
+    return *this;
+  }
+
+  template <class Array>
+  template <class T, class Alloc, class EnableIf>
+  basic_array<Array>& basic_array<Array>::operator =(std::vector<T, Alloc>&& vec) & {
+    val = convert::cast<value_type>(std::move(vec));
+    return *this;
+  }
+
+  template <class Array>
+  template <class T, size_t len, class EnableIf>
+  basic_array<Array>& basic_array<Array>::operator =(std::array<T, len> const& arr) & {
+    val = convert::cast<value_type>(arr);
+    return *this;
+  }
+
+  template <class Array>
+  template <class T, size_t len, class EnableIf>
+  basic_array<Array>& basic_array<Array>::operator =(std::array<T, len>&& arr) & {
+    val = convert::cast<value_type>(std::move(arr));
+    return *this;
   }
 
   template <class String>
-  template <class OtherString>
-  bool basic_string<String>::operator !=(basic_string<OtherString> const& other) const noexcept {
-    return !(*this == other);
+  template <class Str, class EnableIf>
+  basic_string<String>& basic_string<String>::operator =(shim::string_view str) & {
+    val = convert::cast<value_type>(str);
+    return *this;
   }
 
   template <class Number>
-  template <class OtherNumber>
-  bool basic_number<Number>::operator !=(basic_number<OtherNumber> const& other) const noexcept {
-    return !(*this == other);
+  template <class Num, class EnableIf>
+  basic_number<Number>& basic_number<Number>::operator =(Num val) & {
+    this->val = convert::cast<value_type>(val);
+    return *this;
   }
 
   template <class Boolean>
-  template <class OtherBoolean>
-  bool basic_flag<Boolean>::operator !=(basic_flag<OtherBoolean> const& other) const noexcept {
-    return !(*this == other);
+  template <class Bool, class EnableIf>
+  basic_flag<Boolean>& basic_flag<Boolean>::operator =(bool val) & {
+    this->val = convert::cast<value_type>(val);
+    return *this;
   }
 
   template <class Null>
-  template <class OtherNull>
-  constexpr bool basic_null<Null>::operator !=(basic_null<OtherNull> const& other) const noexcept {
-    return !(*this == other);
+  basic_null<Null>& basic_null<Null>::operator =(std::nullptr_t) & {
+    return *this;
   }
 
   template <class String>
@@ -312,33 +322,63 @@ namespace dart {
   }
 
   template <class Object>
-  auto basic_object<Object>::dynamic() const noexcept -> value_type const& {
+  auto basic_object<Object>::dynamic() const& noexcept -> value_type const& {
+    return val;
+  }
+
+  template <class Object>
+  auto basic_object<Object>::dynamic() && noexcept -> value_type&& {
+    return std::move(val);
+  }
+
+  template <class Array>
+  auto basic_array<Array>::dynamic() const& noexcept -> value_type const& {
     return val;
   }
 
   template <class Array>
-  auto basic_array<Array>::dynamic() const noexcept -> value_type const& {
+  auto basic_array<Array>::dynamic() && noexcept -> value_type&& {
+    return std::move(val);
+  }
+
+  template <class String>
+  auto basic_string<String>::dynamic() const& noexcept -> value_type const& {
     return val;
   }
 
   template <class String>
-  auto basic_string<String>::dynamic() const noexcept -> value_type const& {
+  auto basic_string<String>::dynamic() && noexcept -> value_type&& {
+    return std::move(val);
+  }
+
+  template <class Number>
+  auto basic_number<Number>::dynamic() const& noexcept -> value_type const& {
     return val;
   }
 
   template <class Number>
-  auto basic_number<Number>::dynamic() const noexcept -> value_type const& {
+  auto basic_number<Number>::dynamic() && noexcept -> value_type&& {
+    return std::move(val);
+  }
+
+  template <class Boolean>
+  auto basic_flag<Boolean>::dynamic() const& noexcept -> value_type const& {
     return val;
   }
 
   template <class Boolean>
-  auto basic_flag<Boolean>::dynamic() const noexcept -> value_type const& {
+  auto basic_flag<Boolean>::dynamic() && noexcept -> value_type&& {
+    return std::move(val);
+  }
+
+  template <class Null>
+  auto basic_null<Null>::dynamic() const& noexcept -> value_type const& {
     return val;
   }
 
   template <class Null>
-  auto basic_null<Null>::dynamic() const noexcept -> value_type const& {
-    return val;
+  auto basic_null<Null>::dynamic() && noexcept -> value_type&& {
+    return std::move(val);
   }
 
   template <class Object>

--- a/include/dart/buffer/api.tcc
+++ b/include/dart/buffer/api.tcc
@@ -60,29 +60,6 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
-  template <template <class> class OtherRC>
-  bool basic_buffer<RefCount>::operator ==(basic_buffer<OtherRC> const& other) const noexcept {
-    // Check if we're comparing against ourselves.
-    // Cast is necessary to ensure validity if we're comparing
-    // against a different refcounter.
-    if (static_cast<void const*>(this) == static_cast<void const*>(&other)) return true;
-
-    // Check if we're sure we're even the same type.
-    if (is_null() && other.is_null()) return true;
-    else if (get_type() != other.get_type()) return false;
-    else if (raw.buffer == other.raw.buffer) return true;
-
-    // Fall back on a comparison of the underlying buffers.
-    return detail::buffer_equal<RefCount>(raw, other.raw);
-  }
-
-  template <template <class> class RefCount>
-  template <template <class> class OtherRC>
-  bool basic_buffer<RefCount>::operator !=(basic_buffer<OtherRC> const& other) const noexcept {
-    return !(*this == other);
-  }
-
-  template <template <class> class RefCount>
   auto basic_buffer<RefCount>::operator ->() noexcept -> basic_buffer* {
     return this;
   }

--- a/include/dart/common.h
+++ b/include/dart/common.h
@@ -103,6 +103,51 @@ namespace dart {
 
   namespace detail {
 
+    template <class T>
+    struct is_dart_type : std::false_type {};
+    template <template <class> class RC>
+    struct is_dart_type<dart::basic_heap<RC>> : std::true_type {};
+    template <template <class> class RC>
+    struct is_dart_type<dart::basic_buffer<RC>> : std::true_type {};
+    template <template <class> class RC>
+    struct is_dart_type<dart::basic_packet<RC>> : std::true_type {};
+
+    template <class T>
+    struct is_wrapper_type : std::false_type {};
+    template <class T>
+    struct is_wrapper_type<dart::basic_object<T>> : std::true_type {};
+    template <class T>
+    struct is_wrapper_type<dart::basic_array<T>> : std::true_type {};
+    template <class T>
+    struct is_wrapper_type<dart::basic_string<T>> : std::true_type {};
+    template <class T>
+    struct is_wrapper_type<dart::basic_number<T>> : std::true_type {};
+    template <class T>
+    struct is_wrapper_type<dart::basic_flag<T>> : std::true_type {};
+    template <class T>
+    struct is_wrapper_type<dart::basic_null<T>> : std::true_type {};
+
+    template <class T>
+    struct is_dart_api_type : std::false_type {};
+    template <template <class> class RC>
+    struct is_dart_api_type<dart::basic_heap<RC>> : std::true_type {};
+    template <template <class> class RC>
+    struct is_dart_api_type<dart::basic_buffer<RC>> : std::true_type {};
+    template <template <class> class RC>
+    struct is_dart_api_type<dart::basic_packet<RC>> : std::true_type {};
+    template <class T>
+    struct is_dart_api_type<dart::basic_object<T>> : std::true_type {};
+    template <class T>
+    struct is_dart_api_type<dart::basic_array<T>> : std::true_type {};
+    template <class T>
+    struct is_dart_api_type<dart::basic_string<T>> : std::true_type {};
+    template <class T>
+    struct is_dart_api_type<dart::basic_number<T>> : std::true_type {};
+    template <class T>
+    struct is_dart_api_type<dart::basic_flag<T>> : std::true_type {};
+    template <class T>
+    struct is_dart_api_type<dart::basic_null<T>> : std::true_type {};
+
     /**
      *  @brief
      *  Enum encodes the type of an individual packet instance.
@@ -1149,16 +1194,6 @@ namespace dart {
         return generic_deref<RefCount>([] (auto& v) { return v.get_sizeof(); }, elem);
       } else {
         return 0;
-      }
-    }
-
-    template <template <class> class RefCount>
-    bool buffer_equal(raw_element lhs, raw_element rhs) {
-      auto lhs_size = find_sizeof<RefCount>(lhs), rhs_size = find_sizeof<RefCount>(rhs);
-      if (lhs_size == rhs_size) {
-        return std::equal(lhs.buffer, lhs.buffer + lhs_size, rhs.buffer);
-      } else {
-        return false;
       }
     }
 

--- a/include/dart/connector/yaml.tcc
+++ b/include/dart/connector/yaml.tcc
@@ -147,7 +147,7 @@ namespace dart {
           // Cleanup anything allocated for this event.
           yaml_event_delete(&event);
         } while (event_type != YAML_STREAM_END_EVENT && event_type != YAML_DOCUMENT_END_EVENT);
-      } catch (std::exception) {
+      } catch (std::exception const&) {
         // Release memory and rethrow;
         yaml_event_delete(&event);
         yaml_parser_delete(&parser);

--- a/include/dart/conversion_traits.h
+++ b/include/dart/conversion_traits.h
@@ -4,7 +4,6 @@
 /*----- System Includes -----*/
 
 #include <type_traits>
-#include <unordered_map>
 
 /*----- Local Includes -----*/
 
@@ -23,7 +22,9 @@ namespace dart {
     template <class T>
     struct to_dart {
       template <class Packet>
-      static Packet cast(meta::nonesuch);
+      Packet cast(meta::nonesuch);
+      template <class Packet>
+      bool compare(Packet const&, meta::nonesuch);
     };
 
     namespace detail {
@@ -36,6 +37,126 @@ namespace dart {
       struct wrapper_tag {};
       struct dart_tag {};
       struct user_tag {};
+
+      // Struct is basically a switch table of different Dart comparison operations
+      // where both lhs and rhs are known to be specializations of the same Dart
+      // template, even if instantiated with different reference counters.
+      template <class PacketType>
+      struct typed_compare;
+      template <template <class> class RefCount>
+      struct typed_compare<basic_heap<RefCount>> {
+        template <class OtherHeap>
+        static bool compare(basic_heap<RefCount> const& lhs, OtherHeap const& rhs) noexcept {
+          // Check if we're comparing against ourselves.
+          // Cast is necessary to ensure validity if we're comparing
+          // against a different refcounter.
+          if (static_cast<void const*>(&lhs) == static_cast<void const*>(&rhs)) return true;
+
+          // Check if we're even the same type.
+          if (lhs.is_null() && rhs.is_null()) return true;
+          else if (lhs.get_type() != rhs.get_type()) return false;
+
+          // Defer to our underlying representation.
+          return shim::visit([] (auto& lhs, auto& rhs) {
+            using Lhs = std::decay_t<decltype(lhs)>;
+            using Rhs = std::decay_t<decltype(rhs)>;
+
+            // Have to compare through pointers here, and we make the decision purely off of the
+            // ability to dereference the incoming type to try to allow compatibility with custom
+            // external smart-pointers that otherwise conform to the std::shared_ptr interface.
+            auto comparator = dart::detail::typeless_comparator {};
+            auto& lval = dart::detail::maybe_dereference(lhs, meta::is_dereferenceable<Lhs> {});
+            auto& rval = dart::detail::maybe_dereference(rhs, meta::is_dereferenceable<Rhs> {});
+            return comparator(lval, rval);
+          }, lhs.data, rhs.data);
+        }
+      };
+      template <template <class> class RefCount>
+      struct typed_compare<basic_buffer<RefCount>> {
+        template <class OtherBuffer>
+        static bool compare(basic_buffer<RefCount> const& lhs, OtherBuffer const& rhs) noexcept {
+          // Check if we're comparing against ourselves.
+          // Cast is necessary to ensure validity if we're comparing
+          // against a different refcounter.
+          if (static_cast<void const*>(&lhs) == static_cast<void const*>(&rhs)) return true;
+
+          // Check if we're sure we're even the same type.
+          auto rawlhs = lhs.raw, rawrhs = rhs.raw;
+          if (lhs.is_null() && rhs.is_null()) return true;
+          else if (lhs.get_type() != rhs.get_type()) return false;
+          else if (rawlhs.buffer == rawrhs.buffer) return true;
+
+          // Fall back on a comparison of the underlying buffers.
+          auto lhs_size = dart::detail::find_sizeof<RefCount>(rawlhs);
+          auto rhs_size = dart::detail::find_sizeof<RefCount>(rawrhs);
+          if (lhs_size == rhs_size) {
+            return std::equal(rawlhs.buffer, rawlhs.buffer + lhs_size, rawrhs.buffer);
+          } else {
+            return false;
+          }
+        }
+      };
+      template <template <class> class RefCount>
+      struct typed_compare<basic_packet<RefCount>> {
+        template <class OtherPacket>
+        static bool compare(basic_packet<RefCount> const& lhs, OtherPacket const& rhs) noexcept {
+          // Check if we're comparing against ourselves.
+          // Cast is necessary to ensure validity if we're comparing
+          // against a different refcounter.
+          if (static_cast<void const*>(&lhs) == static_cast<void const*>(&rhs)) return true;
+          return shim::visit([] (auto& lhs, auto& rhs) { return lhs == rhs; }, lhs.impl, rhs.impl);
+        }
+      };
+
+      // Function implements the fallback case where we've been asked to compare two
+      // Dart types which have been instantiated off of different base templates.
+      template <class Lhs, class Rhs>
+      bool generic_compare(Lhs const& lhs, Rhs const& rhs) noexcept {
+        // Make sure they're at least of the same type.
+        if (lhs.get_type() != rhs.get_type()) return false;
+
+        // Perform type specific comparisons.
+        switch (lhs.get_type()) {
+          case dart::detail::type::object:
+            {
+              // Bail early if we can.
+              if (lhs.size() != rhs.size()) return false;
+
+              // Ouch.
+              // Iterates over rhs and looks up into lhs because lhs is the finalized
+              // object and lookups should be significantly faster on it.
+              typename std::decay_t<Rhs>::iterator k, v;
+              std::tie(k, v) = rhs.kvbegin();
+              while (v != rhs.end()) {
+                if (*v != lhs[*k]) return false;
+                ++k, ++v;
+              }
+              return true;
+            }
+          case dart::detail::type::array:
+            {
+              // Bail early if we can.
+              if (lhs.size() != rhs.size()) return false;
+
+              // Ouch.
+              for (auto i = 0U; i < lhs.size(); ++i) {
+                if (lhs[i] != rhs[i]) return false;
+              }
+              return true;
+            }
+          case dart::detail::type::string:
+            return lhs.strv() == rhs.strv();
+          case dart::detail::type::integer:
+            return lhs.integer() == rhs.integer();
+          case dart::detail::type::decimal:
+            return lhs.decimal() == rhs.decimal();
+          case dart::detail::type::boolean:
+            return lhs.boolean() == rhs.boolean();
+          default:
+            DART_ASSERT(lhs.is_null());
+            return true;
+        }
+      }
 
       // Meta-function normalizes any conceivable type into one of
       // eight cases that can then be individually processed.
@@ -122,7 +243,174 @@ namespace dart {
       // Makes the question of whether a user conversion is defined SFINAEable
       // so that it can be used in meta::is_detected.
       template <class T, class Packet>
-      using user_cast_t = decltype(to_dart<std::decay_t<T>>::template cast<Packet>(std::declval<T>()));
+      using user_cast_t =
+          decltype(std::declval<to_dart<std::decay_t<T>>>().template cast<Packet>(std::declval<T>()));
+
+      // Makes the question of whether a user comparison is defined SFINAEable
+      // so that it can be used in meta::is_detected.
+      template <class T, class Packet>
+      using user_compare_t =
+          decltype(std::declval<to_dart<std::decay_t<T>>>().compare(std::declval<Packet const&>(), std::declval<T>()));
+
+      template <class T, class Packet>
+      using nothrow_user_compare_t = std::enable_if_t<
+        noexcept(std::declval<to_dart<std::decay_t<T>>>().compare(std::declval<Packet const&>(), std::declval<T>()))
+      >;
+
+      // Calculates if two dart types are using the same reference counter
+      // implementation, even if the two dart types aren't the same.
+      template <class PacketOne, class PacketTwo>
+      struct same_refcounter : std::false_type {};
+      template <template <class> class RefCount,
+               template <template <class> class> class PacketOne,
+               template <template <class> class> class PacketTwo>
+      struct same_refcounter<PacketOne<RefCount>, PacketTwo<RefCount>> : std::true_type {};
+
+      // Calculates if two dart types are using the same base template,
+      // event if the supplied reference counters aren't the same.
+      template <class PacketOne, class PacketTwo>
+      struct same_packet : std::false_type {};
+      template <template <class> class LhsRC,
+               template <class> class RhsRC,
+               template <template <class> class> class Packet>
+      struct same_packet<Packet<LhsRC>, Packet<RhsRC>> : std::true_type {};
+
+      // Calculates if two Dart wrapper types are using the same reference counter
+      // implementation, even if those two wrapper types are using different
+      // implementation types.
+      template <class Packet, class Wrapper>
+      struct same_wrapped_refcounter : std::false_type {};
+      template <template <class> class RefCount,
+               template <class> class Wrapper,
+               template <template <class> class> class PacketOne,
+               template <template <class> class> class PacketTwo>
+      struct same_wrapped_refcounter<
+        PacketOne<RefCount>,
+        Wrapper<PacketTwo<RefCount>>
+      > : std::true_type {};
+
+      // Checks if a user defined comparison is guaranteed
+      // to never throw an exception
+      template <class T, class Packet>
+      struct user_compare_is_nothrow :
+        meta::is_detected<
+          nothrow_user_compare_t,
+          T,
+          Packet
+        >
+      {};
+
+      // Checks if a given type and Dart type can be compared
+      template <class T, class Packet, class Category>
+      struct are_comparable_impl :
+        // We're comparable if...
+        meta::disjunction<
+          // We've been given a user type...
+          meta::conjunction<
+            std::is_same<
+              Category,
+              convert::detail::user_tag
+            >,
+
+            // And the user has specialized the user equality struct.
+            meta::is_detected<
+              detail::user_compare_t,
+              T,
+              Packet
+            >
+          >,
+
+          // Else, we're comparable if we're a built in or internal type.
+          meta::negation<
+            std::is_same<
+              Category,
+              convert::detail::user_tag
+            >
+          >
+        >
+      {};
+
+      // Check if a given type and Dart type can be compared,
+      // and would be guaranteed not to throw an exception if so
+      template <class T, class Packet, class Category>
+      struct are_nothrow_comparable_impl :
+        // We're nothrow comparable if...
+        meta::conjunction<
+          // We're comparable at all...
+          are_comparable_impl<T, Packet, Category>,
+
+          // And...
+          meta::disjunction<
+            // We're either a built in, or internal, type...
+            meta::negation<
+              std::is_same<
+                Category,
+                convert::detail::user_tag
+              >
+            >,
+            
+            // Or the user defined comparison is nothrow.
+            user_compare_is_nothrow<T, Packet>
+          >
+        >
+      {};
+
+      // The dart::convert::are_comparable type trait can receive
+      // arguments in either order, so this dispatch struct takes care
+      // of figuring out what order the arguments were passed in so that
+      // the implementation struct can make concrete assumptions about
+      // what its arguments represent
+      template <template <class, class, class> class Impl,
+               class LhsCat, class RhsCat, class Lhs, class Rhs>
+      struct are_comparable_dispatch;
+
+      // Case: Dart type and Dart type. Must exist to avoid ambiguity
+      template <template <class, class, class> class Impl, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, dart_tag, dart_tag, Lhs, Rhs> :
+        Impl<Lhs, Rhs, dart_tag>
+      {};
+
+      // Case: Dart type and wrapper type. Must exist to avoid ambiguity
+      template <template <class, class, class> class Impl, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, dart_tag, wrapper_tag, Lhs, Rhs> :
+        Impl<Rhs, Lhs, wrapper_tag>
+      {};
+
+      // Case: Wrapper type and Dart type. Must exist to avoid ambiguity.
+      template <template <class, class, class> class Impl, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, wrapper_tag, dart_tag, Lhs, Rhs> :
+        Impl<Lhs, Rhs, wrapper_tag>
+      {};
+
+      // Case: Wrapper type and wrapper type. Must exist to avoid ambiguity.
+      template <template <class, class, class> class Impl, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, wrapper_tag, wrapper_tag, Lhs, Rhs> :
+        Impl<Lhs, typename std::decay_t<Rhs>::value_type, wrapper_tag>
+      {};
+
+      // Case: Dart type and user type.
+      template <template <class, class, class> class Impl, class FreeCat, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, dart_tag, FreeCat, Lhs, Rhs> :
+        Impl<Rhs, Lhs, FreeCat>
+      {};
+
+      // Case: Wrapper type and user type.
+      template <template <class, class, class> class Impl, class FreeCat, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, wrapper_tag, FreeCat, Lhs, Rhs> :
+        Impl<Rhs, typename std::decay_t<Lhs>::value_type, FreeCat>
+      {};
+
+      // Case: User type and Dart type.
+      template <template <class, class, class> class Impl, class FreeCat, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, FreeCat, dart_tag, Lhs, Rhs> :
+        Impl<Lhs, Rhs, FreeCat>
+      {};
+
+      // Case: User type and wrapper type.
+      template <template <class, class, class> class Impl, class FreeCat, class Lhs, class Rhs>
+      struct are_comparable_dispatch<Impl, FreeCat, wrapper_tag, Lhs, Rhs> :
+        Impl<Lhs, typename std::decay_t<Rhs>::value_type, FreeCat>
+      {};
 
       // Switch table implementation for type conversions.
       template <class T>
@@ -205,7 +493,7 @@ namespace dart {
         // Hands off to the conversion logic for the underlying implementation type.
         template <class Packet, class Wrapper>
         static Packet cast(Wrapper&& wrapper) {
-          return caster_impl<dart_tag>::cast<Packet>(std::forward<Wrapper>(wrapper).val);
+          return caster_impl<dart_tag>::cast<Packet>(std::forward<Wrapper>(wrapper).dynamic());
         }
       };
       template <>
@@ -214,34 +502,276 @@ namespace dart {
         // that has a defined conversion.
         template <class Packet, class T>
         static Packet cast(T&& val) {
-          return to_dart<std::decay_t<T>>::template cast<Packet>(std::forward<T>(val));
+          return to_dart<std::decay_t<T>> {}.template cast<Packet>(std::forward<T>(val));
         }
       };
 
-      // Calculates if two dart types are using the same reference counter
-      // implementation, even if the two dart types aren't the same.
-      template <class PacketOne, class PacketTwo>
-      struct same_refcounter : std::false_type {};
-      template <template <class> class RefCount,
-               template <template <class> class> class PacketOne,
-               template <template <class> class> class PacketTwo>
-      struct same_refcounter<PacketOne<RefCount>, PacketTwo<RefCount>> : std::true_type {};
+      // Switch table implementation for Dart comparisons
+      template <class T>
+      struct compare_impl;
+      template <>
+      struct compare_impl<null_tag> {
+        template <class Packet>
+        static bool compare(Packet const& pkt, std::nullptr_t) noexcept {
+          return pkt.is_null();
+        }
+      };
+      template <>
+      struct compare_impl<boolean_tag> {
+        template <class Packet>
+        static bool compare(Packet const& pkt, bool val) noexcept {
+          return pkt.is_boolean() && pkt.boolean() == val;
+        }
+      };
+      template <>
+      struct compare_impl<integer_tag> {
+        template <class Packet>
+        static bool compare(Packet const& pkt, int64_t val) noexcept {
+          return pkt.is_integer() && pkt.integer() == val;
+        }
+      };
+      template <>
+      struct compare_impl<decimal_tag> {
+        template <class Packet>
+        static bool compare(Packet const& pkt, double val) noexcept {
+          return pkt.is_decimal() && pkt.decimal() == val;
+        }
+      };
+      template <>
+      struct compare_impl<string_tag> {
+        template <class Packet>
+        static bool compare(Packet const& pkt, shim::string_view val) noexcept {
+          return pkt.is_str() && pkt.strv() == val;
+        }
+      };
+      template <>
+      struct compare_impl<dart_tag> {
+        // Handles the case where the packet templates in use
+        // are the same, even if the chosen reference counter is not.
+        // Since both lhs and rhs are based off of the same template class,
+        // we can use internal implementation details to perform comparison
+        // faster.
+        // MUCH faster in the case of dart::basic_buffer.
+        template <class LhsPacket, class RhsPacket,
+          std::enable_if_t<
+            same_packet<
+              LhsPacket,
+              RhsPacket
+            >::value
+          >* = nullptr
+        >
+        static bool compare(LhsPacket const& lhs, RhsPacket const& rhs) noexcept {
+          return typed_compare<LhsPacket>::compare(lhs, rhs);
+        }
 
-      // Calculates if two Dart wrapper types are using the same reference counter
-      // implementation, even if those two wrapper types are using different
-      // implementation types.
-      template <class Packet, class Wrapper>
-      struct same_wrapped_refcounter : std::false_type {};
-      template <template <class> class RefCount,
-               template <class> class Wrapper,
-               template <template <class> class> class PacketOne,
-               template <template <class> class> class PacketTwo>
-      struct same_wrapped_refcounter<
-        PacketOne<RefCount>,
-        Wrapper<PacketTwo<RefCount>>
-      > : std::true_type {};
+        // Handles the case where the packet templates in use
+        // are NOT the same, regardless of the chosen reference counter.
+        // Since lhs and rhs are NOT based off of the same template class,
+        // we use the public API to avoid going insane
+        template <class LhsPacket, class RhsPacket,
+          std::enable_if_t<
+            !same_packet<
+              LhsPacket,
+              RhsPacket
+            >::value
+          >* = nullptr
+        >
+        static bool compare(LhsPacket const& lhs, RhsPacket const& rhs) noexcept {
+          // Lookups are faster on finalized objects, so dispatch such that
+          // we attempt to perform lookups against the finalized object.
+          if (lhs.is_finalized()) {
+            return generic_compare(lhs, rhs);
+          } else {
+            return generic_compare(rhs, lhs);
+          }
+        }
+      };
+      template <>
+      struct compare_impl<wrapper_tag> {
+        template <class Packet, class Wrapper>
+        static bool compare(Packet const& pkt, Wrapper const& wrap) noexcept {
+          return compare_impl<dart_tag>::compare(pkt, wrap.dynamic());
+        }
+      };
+      template <>
+      struct compare_impl<user_tag> {
+        template <class Packet, class T>
+        static bool compare(Packet const& pkt, T const& val) noexcept(user_compare_is_nothrow<Packet, T>::value) {
+          return to_dart<std::decay_t<T>> {}.compare(pkt, val);
+        }
+      };
+
+      // These overloads have to exist to avoid overload ambiguity.
+      // Argument order is not enormously significant.
+      // Performs all calls in terms of dart_tag as wrapper_tag just defers to dart_tag.
+      template <class Lhs, class Rhs>
+      bool compare_dispatch(dart_tag, dart_tag, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<dart_tag>::compare(lhs, rhs);
+      }
+      template <class Lhs, class Rhs>
+      bool compare_dispatch(dart_tag, wrapper_tag, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<dart_tag>::compare(lhs, rhs.dynamic());
+      }
+      template <class Lhs, class Rhs>
+      bool compare_dispatch(wrapper_tag, dart_tag, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<dart_tag>::compare(rhs, lhs.dynamic());
+      }
+      template <class Lhs, class Rhs>
+      bool compare_dispatch(wrapper_tag, wrapper_tag, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<dart_tag>::compare(lhs.dynamic(), rhs.dynamic());
+      }
+
+      // These are the actual important calls, and argument order is significant as
+      // all of the compare_impl functions expect Lhs to be a dart type.
+      // The purpose of this whole run-around is so that the user can pass arguments
+      // into dart::convert::compare in either order, and pass either a dart packet type,
+      // or a wrapper type, without issue.
+      template <class Free, class Lhs, class Rhs>
+      bool compare_dispatch(dart_tag, Free, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<Free>::compare(lhs, rhs);
+      }
+      template <class Free, class Lhs, class Rhs>
+      bool compare_dispatch(wrapper_tag, Free, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<Free>::compare(lhs.dynamic(), rhs);
+      }
+      template <class Free, class Lhs, class Rhs>
+      bool compare_dispatch(Free, dart_tag, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<Free>::compare(rhs, lhs);
+      }
+      template <class Free, class Lhs, class Rhs>
+      bool compare_dispatch(Free, wrapper_tag, Lhs const& lhs, Rhs const& rhs) {
+        return detail::compare_impl<Free>::compare(rhs.dynamic(), lhs);
+      }
 
     }
+
+    /**
+     *  @brief
+     *  Meta-function calculates whether a call to dart::convert::cast will be well-formed
+     *  for a particular T and TargetPacket type.
+     *
+     *  @details
+     *  The expression:
+     *  ```
+     *  static_assert(dart::convert::is_castable<T, dart::packet>::value);
+     *  ```
+     *  Will compile successfully for any T that is either a builtin machine type,
+     *  is an STL container of builtin machine types, is a user type for which
+     *  a conversion has been defined using the conversion API, or is an STL container
+     *  of such a user type.
+     */
+    template <class T, class TargetPacket, class Normalized = detail::normalize_t<T>>
+    struct is_castable : 
+      // The given type is castable if...
+      meta::disjunction<
+        // It is a built in type.
+        meta::contained<
+          Normalized,
+          convert::detail::string_tag,
+          convert::detail::decimal_tag,
+          convert::detail::integer_tag,
+          convert::detail::boolean_tag,
+          convert::detail::null_tag
+        >,
+
+        // It is a dart type...
+        meta::conjunction<
+          std::is_same<
+            Normalized,
+            convert::detail::dart_tag
+          >,
+
+          // And the reference counters are the same.
+          detail::same_refcounter<
+            TargetPacket,
+            std::decay_t<T>
+          >
+        >,
+
+        // It is a dart wrapper type...
+        meta::conjunction<
+          std::is_same<
+            Normalized,
+            convert::detail::wrapper_tag
+          >,
+
+          // And the reference counters are the same.
+          detail::same_wrapped_refcounter<
+            TargetPacket,
+            std::decay_t<T>
+          >
+        >,
+
+        // It is a user type...
+        meta::conjunction<
+          std::is_same<
+            Normalized,
+            convert::detail::user_tag
+          >,
+
+          // And the user has specialized the user conversion struct.
+          meta::is_detected<
+            detail::user_cast_t,
+            T,
+            TargetPacket
+          >
+        >
+      >
+    {};
+
+    /**
+     *  @brief
+     *  Meta-function calculates whether a call to dart::convert::compare will be well-formed
+     *  for a particular T and Dart type. Arguments can be passed in either order, at least one
+     *  must be known to be a Dart type.
+     *
+     *  @details
+     *  The expression:
+     *  ```
+     *  static_assert(dart::convert::are_comparable<T, dart::packet>::value);
+     *  ```
+     *  Will compile successfully for any T that is either a builtin machine type,
+     *  is an STL container of builtin machine types, is a user type for which
+     *  a comparison has been defined using the comparison API, or is an STL container
+     *  of such a user type.
+     */
+    template <class Lhs, class Rhs>
+    struct are_comparable :
+      detail::are_comparable_dispatch<
+        detail::are_comparable_impl,
+        detail::normalize_t<Lhs>,
+        detail::normalize_t<Rhs>,
+        Lhs,
+        Rhs
+      >
+    {};
+
+    /**
+     *  @brief
+     *  Meta-function calculates whether a call to dart::convert::compare will be well-formed
+     *  and is guaranteed not to throw exceptions for a particular T and Dart type.
+     *  Arguments can be passed in either order, at least one must be known to be a Dart type.
+     *
+     *  @details
+     *  The expression:
+     *  ```
+     *  static_assert(dart::convert::are_nothrow_comparable<T, dart::packet>::value);
+     *  ```
+     *  Will compile successfully for any T that is either a builtin machine type,
+     *  is an STL container of builtin machine types, is a user type for which
+     *  a comparison has been defined using the comparison API and is marked noexcept,
+     *  or is an STL container of such a user type.
+     */
+    template <class Lhs, class Rhs>
+    struct are_nothrow_comparable :
+      detail::are_comparable_dispatch<
+        detail::are_nothrow_comparable_impl,
+        detail::normalize_t<Lhs>,
+        detail::normalize_t<Rhs>,
+        Lhs,
+        Rhs
+      >
+    {};
 
     /**
      *  @brief
@@ -269,7 +799,7 @@ namespace dart {
      *    template <>
      *    struct to_dart<my_string> {
      *      template <class Packet>
-     *      static Packet cast(my_string const& s) {
+     *      Packet cast(my_string const& s) {
      *        return Packet::make_string(s.str);
      *      }
      *    };
@@ -283,72 +813,42 @@ namespace dart {
 
     /**
      *  @brief
-     *  Meta-function calculates whether a call to dart::convert::cast will be well-formed
-     *  for a particular T and TargetPacket type.
+     *  Function can be used to compare a Dart type against any registered type.
      *
      *  @details
-     *  The expression:
+     *  Say you had a simple custom string class along the lines of the following:
      *  ```
-     *  static_assert(dart::convert::is_castable<T, dart::packet>::value);
+     *  struct my_string {
+     *    std::string str;
+     *  };
      *  ```
-     *  Will compile successfully for any T that is either a builtin machine type,
-     *  is an STL container of builtin machine types, is a user type for which
-     *  a conversion has been defined using the conversion API, or is an STL container
-     *  of such a user type.
+     *  And you wanted to be able to perform operations like so:
+     *  ```
+     *  dart::string str {"hello"};
+     *  my_string mystr {"hello"};
+     *  assert(str == mystr);
+     *  ```
+     *  You can accomplish this by specializing the struct `dart::convert::to_dart`
+     *  with your custom type and implementing a compare function like so:
+     *  ```
+     *  namespace dart::convert {
+     *    template <>
+     *    struct to_dart<my_string> {
+     *      template <class Packet>
+     *      bool compare(Packet const& pkt, my_string const& s) {
+     *        return pkt.strv() == s.str;
+     *      }
+     *    };
+     *  }
+     *  ```
      */
-    template <class T, class TargetPacket, class Normalized = detail::normalize_t<T>>
-    struct is_castable : 
-      meta::disjunction<
-        // We can cast if given a builtin type
-        meta::contained<
-          Normalized,
-          convert::detail::string_tag,
-          convert::detail::decimal_tag,
-          convert::detail::integer_tag,
-          convert::detail::boolean_tag,
-          convert::detail::null_tag
-        >,
+    template <class Lhs, class Rhs>
+    bool compare(Lhs const& lhs, Rhs const& rhs) noexcept(are_nothrow_comparable<Lhs, Rhs>::value) {
+      return detail::compare_dispatch(detail::normalize_t<Lhs> {}, detail::normalize_t<Rhs> {}, lhs, rhs);
+    }
 
-        // If we're attempting to cast a dart type...
-        meta::conjunction<
-          std::is_same<
-            Normalized,
-            convert::detail::dart_tag
-          >,
-          // We can do it if the reference counters are the same.
-          detail::same_refcounter<
-            TargetPacket,
-            std::decay_t<T>
-          >
-        >,
-        // If we're attempting to cast a dart wrapper type...
-        meta::conjunction<
-          std::is_same<
-            Normalized,
-            convert::detail::wrapper_tag
-          >,
-          // We can do it if the reference counters are the same
-          detail::same_wrapped_refcounter<
-            TargetPacket,
-            std::decay_t<T>
-          >
-        >,
-        // If we're attempting to cast a user type...
-        meta::conjunction<
-          std::is_same<
-            Normalized,
-            convert::detail::user_tag
-          >,
-          // We can do it if they've specialized the user cast struct
-          meta::is_detected<
-            detail::user_cast_t,
-            T,
-            TargetPacket
-          >
-        >
-      >
-    {};
-
+    // Converts a sequence of arguments convertible to Dart types
+    // into a gsl::span of Dart types backed by stack-based storage.
     template <class Packet = dart::basic_packet<std::shared_ptr>, class Callback, class... Args, class =
       std::enable_if_t<
         meta::conjunction<
@@ -363,201 +863,6 @@ namespace dart {
       // Pass through as a span.
       return std::forward<Callback>(cb)(gsl::make_span(storage));
     }
-
-    // Specialization for interoperability with std::vector
-    template <class T, class Alloc>
-    struct to_dart<std::vector<T, Alloc>> {
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<T, Packet>::value
-        >
-      >
-      static Packet cast(std::vector<T, Alloc> const& vec) {
-        auto pkt = Packet::make_array();
-        for (auto& val : vec) pkt.push_back(val);
-        return pkt;
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<T, Packet>::value
-        >
-      >
-      static Packet cast(std::vector<T, Alloc>&& vec) {
-        auto pkt = Packet::make_array();
-        for (auto& val : vec) pkt.push_back(std::move(val));
-        return pkt;
-      }
-    };
-
-    // Specialization for interoperability with std::array
-    template <class T, size_t len>
-    struct to_dart<std::array<T, len>> {
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<T, Packet>::value
-        >
-      >
-      static Packet cast(std::array<T, len> const& arr) {
-        auto pkt = Packet::make_array();
-        for (auto& val : arr) pkt.push_back(val);
-        return pkt;
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<T, Packet>::value
-        >
-      >
-      static Packet cast(std::array<T, len>&& arr) {
-        auto pkt = Packet::make_array();
-        for (auto& val : arr) pkt.push_back(std::move(val));
-        return pkt;
-      }
-    };
-
-    // Specialization for interoperability with std::map
-    template <class Key, class Value, class Comp, class Alloc>
-    struct to_dart<std::map<Key, Value, Comp, Alloc>> {
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<Key, Packet>::value
-          &&
-          convert::is_castable<Value, Packet>::value
-        >
-      >
-      static Packet cast(std::map<Key, Value, Comp, Alloc> const& map) {
-        auto obj = Packet::make_object();
-        for (auto& pair : map) obj.add_field(pair.first, pair.second);
-        return obj;
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<Key, Packet>::value
-          &&
-          convert::is_castable<Value, Packet>::value
-        >
-      >
-      static Packet cast(std::map<Key, Value, Comp, Alloc>&& map) {
-        auto obj = Packet::make_object();
-        for (auto& pair : map) obj.add_field(std::move(pair).first, std::move(pair).second);
-        return obj;
-      }
-    };
-
-    // Specialization for interoperability with std::unordered_map
-    template <class Key, class Value, class Hash, class Equal, class Alloc>
-    struct to_dart<std::unordered_map<Key, Value, Hash, Equal, Alloc>> {
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<Key, Packet>::value
-          &&
-          convert::is_castable<Value, Packet>::value
-        >
-      >
-      static Packet cast(std::unordered_map<Key, Value, Hash, Equal, Alloc> const& map) {
-        auto obj = Packet::make_object();
-        for (auto& pair : map) obj.add_field(pair.first, pair.second);
-        return obj;
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<Key, Packet>::value
-          &&
-          convert::is_castable<Value, Packet>::value
-        >
-      >
-      static Packet cast(std::unordered_map<Key, Value, Hash, Equal, Alloc>&& map) {
-        auto obj = Packet::make_object();
-        for (auto& pair : map) obj.add_field(std::move(pair).first, std::move(pair).second);
-        return obj;
-      }
-    };
-
-    // Specialization for interoperability with std::optional.
-    template <class T>
-    struct to_dart<shim::optional<T>> {
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<T, Packet>::value
-        >
-      >
-      static Packet cast(shim::optional<T> const& opt) {
-        if (opt) return convert::cast<Packet>(*opt);
-        else return Packet::make_null();
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          convert::is_castable<T, Packet>::value
-        >
-      >
-      static Packet cast(shim::optional<T>&& opt) {
-        if (opt) return convert::cast<Packet>(std::move(*opt));
-        else return Packet::make_null();
-      }
-    };
-
-    // Specialization for interoperability with std::variant.
-    template <class... Ts>
-    struct to_dart<shim::variant<Ts...>> {
-      template <class Packet, class =
-        std::enable_if_t<
-          meta::conjunction<
-            convert::is_castable<Ts, Packet>...
-          >::value
-        >
-      >
-      static Packet cast(shim::variant<Ts...> const& var) {
-        return shim::visit([] (auto& val) { return convert::cast<Packet>(val); }, var);
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          meta::conjunction<
-            convert::is_castable<Ts, Packet>...
-          >::value
-        >
-      >
-      static Packet cast(shim::variant<Ts...>&& var) {
-        return shim::visit([] (auto&& val) { return convert::cast<Packet>(std::move(val)); }, std::move(var));
-      }
-    };
-
-    // Specialization for interoperability with std::tuple.
-    template <class... Ts>
-    struct to_dart<std::tuple<Ts...>> {
-      template <class Packet, class Tuple, size_t... idxs>
-      static Packet unpack(Tuple&& tup, std::index_sequence<idxs...>) {
-        return Packet::make_array(std::get<idxs>(std::forward<Tuple>(tup))...);
-      }
-
-      template <class Packet, class =
-        std::enable_if_t<
-          meta::conjunction<
-            convert::is_castable<Ts, Packet>...
-          >::value
-        >
-      >
-      static Packet cast(std::tuple<Ts...> const& tup) {
-        return unpack<Packet>(tup, std::index_sequence_for<Ts...> {});
-      }
-      template <class Packet, class =
-        std::enable_if_t<
-          meta::conjunction<
-            convert::is_castable<Ts, Packet>...
-          >::value
-        >
-      >
-      static Packet cast(std::tuple<Ts...>&& tup) {
-        return unpack<Packet>(std::move(tup), std::index_sequence_for<Ts...> {});
-      }
-    };
-
-    // Bizzarely useful in some meta-programming situations.
-    template <class T, T val>
-    struct to_dart<std::integral_constant<T, val>> {
-      template <class Packet>
-      static Packet cast(std::integral_constant<T, val>) {
-        return convert::cast<Packet>(val);
-      }
-    };
 
   }
 

--- a/include/dart/conversions.h
+++ b/include/dart/conversions.h
@@ -1,0 +1,1053 @@
+#ifndef DART_CONVERSIONS_H
+#define DART_CONVERSIONS_H
+
+/*----- System Includes -----*/
+
+#include <set>
+#include <map>
+#include <list>
+#include <deque>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <forward_list>
+#include <unordered_map>
+
+/*----- Local Includes -----*/
+
+#include "conversion_traits.h"
+
+/*----- Type Declarations -----*/
+
+namespace dart {
+
+  namespace convert {
+
+    namespace detail {
+      // This is fairly barbaric, but it lets us hack std::is_permutation
+      // to work when the two iterators don't have the same value type.
+      struct multimap_comparator {
+        template <class T>
+        struct is_pair : std::false_type {};
+        template <class First, class Second>
+        struct is_pair<std::pair<First, Second>> : std::true_type {};
+
+        template <class T, class =
+          std::enable_if_t<
+            !is_pair<T>::value
+          >
+        >
+        bool operator ()(T const& lhs, T const& rhs) const {
+          return lhs == rhs;
+        }
+        template <class First, class Second, class T, class =
+          std::enable_if_t<
+            !is_pair<T>::value
+          >
+        >
+        bool operator ()(std::pair<First, Second> const& lhs, T const& rhs) const {
+          return lhs.second == rhs;
+        }
+        template <class First, class Second, class T, class =
+          std::enable_if_t<
+            !is_pair<T>::value
+          >
+        >
+        bool operator ()(T const& lhs, std::pair<First, Second> const& rhs) const {
+          return lhs == rhs.second;
+        }
+        template <class First, class Second>
+        bool operator ()(std::pair<First, Second> const& lhs, std::pair<First, Second> const& rhs) const {
+          return lhs.second == rhs.second;
+        }
+      };
+
+      template <class Packet, class Map, class Callback>
+      bool generic_map_compare_impl(Packet const& pkt, Map const& map, Callback&& cb) {
+        // Lookup into the packet will be much faster if it's finalized,
+        // and the same if not, so iterate over the map.
+        typename Packet::view v = pkt;
+        for (auto& pair : map) {
+          auto val = cb(v, pair.first);
+          if (val != pair.second) return false;
+        }
+        return true;
+      }
+
+      // General case of comparing a Dart type against a std map.
+      template <class Packet, class Map>
+      bool generic_map_compare(Packet const& pkt, Map const& map, std::true_type) {
+        return generic_map_compare_impl(pkt, map, [] (auto& v, auto& k) { return v[k]; });
+      }
+
+      template <class Packet, class Map>
+      bool generic_map_compare(Packet const& pkt, Map const& map, std::false_type) {
+        // This is truly unfortunate.
+        // The user gave us a map implementation with
+        // a key type that IS convertible into a Dart type,
+        // but which is NOT convertible into std::string_view
+        // which means our only recourse is to create a temporary
+        // packet for each key with which to perform the lookup.
+        return generic_map_compare_impl(pkt, map, [] (auto& v, auto& k) { return v[convert::cast(k)]; });
+      }
+
+      template <class Packet, class Map, class Extract, class Next>
+      bool generic_multimap_compare_impl(Packet const& pkt, Map const& map, Extract&& extract, Next&& next) {
+        auto end = map.end();
+        auto it = map.begin();
+        typename Packet::view v = pkt;
+        while (it != end) {
+          // Find the end iterator for this key
+          auto edge = next(it, end);
+          
+          // Get the Dart equivalent.
+          auto val = extract(v, it->first);
+
+          // Attempt to short-circuit
+          if (!val.is_array()) return false;
+          else if (static_cast<ssize_t>(val.size()) != std::distance(it, edge)) return false;
+
+          // Perform the comparison.
+          auto check = std::is_permutation(it, edge, val.begin(), multimap_comparator {});
+          if (!check) return false;
+
+          // Skip past all records with this key.
+          it = edge;
+        }
+        return true;
+      }
+
+      template <class Packet, class Key, class Value, class Comp, class Alloc>
+      bool generic_multimap_compare(Packet const& pkt,
+          std::multimap<Key, Value, Comp, Alloc> const& map, std::true_type) {
+        auto extract = [] (auto& v, auto& k) {
+          return v[k];
+        };
+        auto next = [&] (auto& it, auto& end) {
+          return std::upper_bound(it, end, *it, map.value_comp());
+        };
+        return generic_multimap_compare_impl(pkt, map, extract, next);
+      }
+
+      template <class Packet, class Key, class Value, class Comp, class Alloc>
+      bool generic_multimap_compare(Packet const& pkt,
+          std::multimap<Key, Value, Comp, Alloc> const& map, std::false_type) {
+        auto extract = [] (auto& v, auto& k) {
+          return v[convert::cast(k)];
+        };
+        auto next = [&] (auto& it, auto& end) {
+          return std::upper_bound(it, end, *it, map.value_comp());
+        };
+        return generic_multimap_compare_impl(pkt, map, extract, next);
+      }
+
+      template <class Packet, class Key, class Value, class Hash, class Equal, class Alloc>
+      bool generic_multimap_compare(Packet const& pkt,
+          std::unordered_multimap<Key, Value, Hash, Equal, Alloc> const& map, std::true_type) {
+        auto extract = [] (auto& v, auto& k) {
+          return v[k];
+        };
+        auto next = [] (auto& it, auto& end) {
+          return std::find_if(it, end, [&] (auto& e) { return e.first != it->first; });
+        };
+        return generic_multimap_compare_impl(pkt, map, extract, next);
+      }
+
+      template <class Packet, class Key, class Value, class Hash, class Equal, class Alloc>
+      bool generic_multimap_compare(Packet const& pkt,
+          std::unordered_multimap<Key, Value, Hash, Equal, Alloc> const& map, std::false_type) {
+        auto extract = [] (auto& v, auto& k) {
+          return v[convert::cast(k)];
+        };
+        auto next = [] (auto& it, auto& end) {
+          return std::find_if(it, end, [&] (auto& e) { return e.first != it->first; });
+        };
+        return generic_multimap_compare_impl(pkt, map, extract, next);
+      }
+
+    }
+
+    // Specialization for interoperability with gsl::span
+    template <class T, std::ptrdiff_t extent>
+    struct to_dart<gsl::span<T, extent>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(gsl::span<T const> span) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(span.size());
+        for (auto& val : span) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, gsl::span<T const> span)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != static_cast<size_t>(span.size())) return false;
+
+        auto it = span.cbegin();
+        typename Packet::view v = pkt;
+        for (auto val : v) {
+          if (val != *it) return false;
+          ++it;
+        }
+        return true;
+      }
+    };
+
+    // Specialization for interoperability with std::vector
+    template <class T, class Alloc>
+    struct to_dart<std::vector<T, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::vector<T, Alloc> const& vec) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(vec.size());
+        for (auto& val : vec) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::vector<T, Alloc>&& vec) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(vec.size());
+        for (auto& val : vec) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::vector<T, Alloc> const& vec)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        // Try to short-circuit.
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != vec.size()) return false;
+
+        // Iterate and check.
+        auto it = vec.cbegin();
+        typename Packet::view v = pkt;
+        for (auto val : v) {
+          if (val != *it) return false;
+          ++it;
+        }
+        return true;
+      }
+    };
+
+    // Specialization for interoperability with std::array
+    template <class T, size_t len>
+    struct to_dart<std::array<T, len>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::array<T, len> const& arr) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(len);
+        for (auto& val : arr) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::array<T, len>&& arr) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(len);
+        for (auto& val : arr) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::array<T, len> const& arr)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        // Try to short-circuit.
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != len) return false;
+
+        // Iterate and check.
+        auto it = arr.cbegin();
+        typename Packet::view v = pkt;
+        for (auto val : v) {
+          if (val != *it) return false;
+          ++it;
+        }
+        return true;
+      }
+    };
+
+    // Specialization for interoperability with std::deque
+    template <class T, class Alloc>
+    struct to_dart<std::deque<T, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::deque<T, Alloc> const& deq) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(deq.size());
+        for (auto& val : deq) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::deque<T, Alloc>&& deq) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(deq.size());
+        for (auto& val : deq) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::deque<T, Alloc> const& deq)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        // Try to short-circuit.
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != deq.size()) return false;
+
+        // Iterate and check.
+        auto it = deq.cbegin();
+        typename Packet::view v = pkt;
+        for (auto val : v) {
+          if (val != *it) return false;
+          ++it;
+        }
+        return true;
+      }
+    };
+
+    // Specialization for interoperability with std::list
+    template <class T, class Alloc>
+    struct to_dart<std::list<T, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::list<T, Alloc> const& lst) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(lst.size());
+        for (auto& val : lst) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::list<T, Alloc>&& lst) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(lst.size());
+        for (auto& val : lst) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::list<T, Alloc> const& lst)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        // Try to short-circuit.
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != lst.size()) return false;
+
+        // Iterate and check.
+        auto it = lst.cbegin();
+        typename Packet::view v = pkt;
+        for (auto val : v) {
+          if (val != *it) return false;
+          ++it;
+        }
+        return true;
+      }
+    };
+
+    // Specialization for interoperability with std::forward_list
+    template <class T, class Alloc>
+    struct to_dart<std::forward_list<T, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::forward_list<T, Alloc> const& lst) {
+        auto pkt = Packet::make_array();
+        for (auto& val : lst) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(std::forward_list<T, Alloc>&& lst) {
+        auto pkt = Packet::make_array();
+        for (auto& val : lst) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      // Template parameter U is unfortunately necessary here to delay
+      // instantiation of the std::enable_if_t to SFINAE properly
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::forward_list<T, Alloc> const& lst)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        // Try to short-circuit.
+        if (!pkt.is_array()) return false;
+
+        // Iterate and check.
+        auto it = lst.cbegin();
+        typename Packet::view v = pkt;
+        for (auto val : v) {
+          if (val != *it) return false;
+          ++it;
+        }
+        return it == lst.cend();
+      }
+    };
+
+    // Specialization for interoperability with std::map
+    template <class Key, class Value, class Comp, class Alloc>
+    struct to_dart<std::map<Key, Value, Comp, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::map<Key, Value, Comp, Alloc> const& map) {
+        auto obj = Packet::make_object();
+        for (auto& pair : map) obj.add_field(pair.first, pair.second);
+        return obj;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::map<Key, Value, Comp, Alloc>&& map) {
+        auto obj = Packet::make_object();
+        for (auto& pair : map) obj.add_field(std::move(pair).first, std::move(pair).second);
+        return obj;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::are_comparable<Key, Packet>::value
+          &&
+          convert::are_comparable<Value, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::map<Key, Value, Comp, Alloc> const& map)
+        noexcept(
+          convert::are_nothrow_comparable<Key, Packet>::value
+          &&
+          convert::are_nothrow_comparable<Value, Packet>::value
+        )
+      {
+        // Try to short-circuit.
+        if (!pkt.is_object()) return false;
+        else if (pkt.size() != map.size()) return false;
+
+        // We have to indirect through an implementation function here to handle an edge
+        // case where the user passed is a map with a key type that IS convertible to a
+        // Dart type, but which is NOT convertible to shim::string_view.
+        return detail::generic_map_compare(pkt, map, std::is_convertible<Key, shim::string_view> {});
+      }
+    };
+
+    // Specialization for interoperability with std::unordered_map
+    template <class Key, class Value, class Hash, class Equal, class Alloc>
+    struct to_dart<std::unordered_map<Key, Value, Hash, Equal, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::unordered_map<Key, Value, Hash, Equal, Alloc> const& map) {
+        auto obj = Packet::make_object();
+        for (auto& pair : map) obj.add_field(pair.first, pair.second);
+        return obj;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::unordered_map<Key, Value, Hash, Equal, Alloc>&& map) {
+        auto obj = Packet::make_object();
+        for (auto& pair : map) obj.add_field(std::move(pair).first, std::move(pair).second);
+        return obj;
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::are_comparable<Key, Packet>::value
+          &&
+          convert::are_comparable<Value, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::unordered_map<Key, Value, Hash, Equal, Alloc> const& map)
+        noexcept(
+          convert::are_nothrow_comparable<Key, Packet>::value
+          &&
+          convert::are_nothrow_comparable<Value, Packet>::value
+        )
+      {
+        // Try to short-circuit.
+        if (!pkt.is_object()) return false;
+        else if (pkt.size() != map.size()) return false;
+
+        // We have to indirect through an implementation function here to handle an edge
+        // case where the user passed is a map with a key type that IS convertible to a
+        // Dart type, but which is NOT convertible to shim::string_view.
+        return detail::generic_map_compare(pkt, map, std::is_convertible<Key, shim::string_view> {});
+      }
+    };
+
+    // Specialization for interoperability with std::map
+    template <class Key, class Value, class Comp, class Alloc>
+    struct to_dart<std::multimap<Key, Value, Comp, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::multimap<Key, Value, Comp, Alloc> const& map) {
+        std::map<Key, typename Packet::array, Comp> accum;
+        for (auto& pair : map) accum[pair.first].push_back(pair.second);
+        return convert::cast<Packet>(std::move(accum));
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::multimap<Key, Value, Comp, Alloc>&& map) {
+        std::map<Key, typename Packet::array, Comp> accum;
+        for (auto& pair : map) accum[pair.first].push_back(std::move(pair.second));
+        return convert::cast<Packet>(std::move(accum));
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::are_comparable<Key, Packet>::value
+          &&
+          convert::are_comparable<Value, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::multimap<Key, Value, Comp, Alloc> const& map)
+        noexcept(
+          convert::are_nothrow_comparable<Key, Packet>::value
+          &&
+          convert::are_nothrow_comparable<Value, Packet>::value
+        )
+      {
+        // Try to short-circuit.
+        if (!pkt.is_object()) return false;
+        return detail::generic_multimap_compare(pkt, map, std::is_convertible<Key, shim::string_view> {});
+      }
+    };
+
+    // Specialization for interoperability with std::map
+    template <class Key, class Value, class Hash, class Equal, class Alloc>
+    struct to_dart<std::unordered_multimap<Key, Value, Hash, Equal, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::unordered_multimap<Key, Value, Hash, Equal, Alloc> const& map) {
+        std::unordered_map<Key, typename Packet::array, Hash, Equal> accum;
+        for (auto& pair : map) accum[pair.first].push_back(pair.second);
+        return convert::cast<Packet>(std::move(accum));
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::is_castable<Value, Packet>::value
+        >
+      >
+      Packet cast(std::unordered_multimap<Key, Value, Hash, Equal, Alloc>&& map) {
+        std::unordered_map<Key, typename Packet::array, Hash, Equal> accum;
+        for (auto& pair : map) accum[pair.first].push_back(std::move(pair.second));
+        return convert::cast<Packet>(std::move(accum));
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+          &&
+          convert::are_comparable<Key, Packet>::value
+          &&
+          convert::are_comparable<Value, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::unordered_multimap<Key, Value, Hash, Equal, Alloc> const& map)
+        noexcept(
+          convert::are_nothrow_comparable<Key, Packet>::value
+          &&
+          convert::are_nothrow_comparable<Value, Packet>::value
+        )
+      {
+        // Try to short-circuit.
+        if (!pkt.is_object()) return false;
+        return detail::generic_multimap_compare(pkt, map, std::is_convertible<Key, shim::string_view> {});
+      }
+    };
+
+    template <class Key, class Compare, class Alloc>
+    struct to_dart<std::set<Key, Compare, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+        >
+      >
+      Packet cast(std::set<Key, Compare, Alloc> const& set) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(set.size());
+        for (auto& val : set) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+        >
+      >
+      Packet cast(std::set<Key, Compare, Alloc>&& set) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(set.size());
+        for (auto& val : set) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      // Template parameter K is unfortunately necessary here to delay
+      // instantiation of the std::enable_if_t to SFINAE properly
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<Key, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::set<Key, Compare, Alloc> const& set)
+        noexcept(convert::are_nothrow_comparable<Key, Packet>::value)
+      {
+        // Try to short-circuit
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != set.size()) return false;
+
+        // Unfortunate, but we have no idea how the given set's comparator
+        // behaves in comparison to the Dart comparator, and we're simulating
+        // sets as arrays, so we don't have any efficient way to look up set
+        // members in constant time.
+        // Thus, this currently hands off to std::is_permutation.
+        return std::is_permutation(pkt.begin(), pkt.end(), set.begin());
+      }
+    };
+
+    template <class Key, class Compare, class Alloc>
+    struct to_dart<std::multiset<Key, Compare, Alloc>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+        >
+      >
+      Packet cast(std::multiset<Key, Compare, Alloc> const& set) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(set.size());
+        for (auto& val : set) pkt.push_back(val);
+        return pkt;
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<Key, Packet>::value
+        >
+      >
+      Packet cast(std::multiset<Key, Compare, Alloc>&& set) {
+        auto pkt = Packet::make_array();
+        pkt.reserve(set.size());
+        for (auto& val : set) pkt.push_back(std::move(val));
+        return pkt;
+      }
+
+      // Equality
+      // Template parameter K is unfortunately necessary here to delay
+      // instantiation of the std::enable_if_t to SFINAE properly
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<Key, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::multiset<Key, Compare, Alloc> const& set)
+        noexcept(convert::are_nothrow_comparable<Key, Packet>::value)
+      {
+        // Try to short-circuit
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != set.size()) return false;
+
+        // FIXME: Need to benchmark this and add a case where it falls back
+        // and constructs a temporary set to perform the comparison.
+        // Unfortunate, but we have no idea how the given set's comparator
+        // behaves in comparison to the Dart comparator, and we're simulating
+        // sets as arrays, so we don't have any efficient way to look up set
+        // members in constant time.
+        // Thus, this currently hands off to std::is_permutation.
+        return std::is_permutation(pkt.begin(), pkt.end(), set.begin());
+      }
+    };
+
+    // Specialization for interoperability with std::optional.
+    template <class T>
+    struct to_dart<shim::optional<T>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(shim::optional<T> const& opt) {
+        if (opt) return convert::cast<Packet>(*opt);
+        else return Packet::make_null();
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<T, Packet>::value
+        >
+      >
+      Packet cast(shim::optional<T>&& opt) {
+        if (opt) return convert::cast<Packet>(std::move(*opt));
+        else return Packet::make_null();
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<T, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, shim::optional<T> const& opt)
+        noexcept(convert::are_nothrow_comparable<T, Packet>::value)
+      {
+        if (opt) return pkt == *opt;
+        else return pkt.is_null();
+      }
+    };
+
+    // Specialization for interoperability with std::variant.
+    template <class... Ts>
+    struct to_dart<shim::variant<Ts...>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          meta::conjunction<
+            convert::is_castable<Ts, Packet>...
+          >::value
+        >
+      >
+      Packet cast(shim::variant<Ts...> const& var) {
+        return shim::visit([] (auto& val) { return convert::cast<Packet>(val); }, var);
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          meta::conjunction<
+            convert::is_castable<Ts, Packet>...
+          >::value
+        >
+      >
+      Packet cast(shim::variant<Ts...>&& var) {
+        return shim::visit([] (auto&& val) { return convert::cast<Packet>(std::move(val)); }, std::move(var));
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          meta::conjunction<
+            convert::are_comparable<Ts, Packet>...
+          >::value
+        >
+      >
+      bool compare(Packet const& pkt, shim::variant<Ts...> const& var)
+        noexcept(
+          meta::conjunction<
+            convert::are_nothrow_comparable<Ts, Packet>...
+          >::value
+        )
+      {
+        return shim::visit([&] (auto& val) { return val == pkt; }, var);
+      }
+    };
+
+    // Specialization for interoperability with std::tuple.
+    template <class... Ts>
+    struct to_dart<std::tuple<Ts...>> {
+      template <class Packet, class Tuple, size_t... idxs>
+      Packet unpack_convert(Tuple&& tup, std::index_sequence<idxs...>) {
+        return Packet::make_array(std::get<idxs>(std::forward<Tuple>(tup))...);
+      }
+
+      template <class PackIt, class Tuple>
+      bool unpack_compare_impl(PackIt&&, Tuple const&) {
+        return true;
+      }
+      template <size_t idx, size_t... idxs, class PackIt, class Tuple>
+      bool unpack_compare_impl(PackIt&& curr, Tuple const& tup) {
+        return (*curr == std::get<idx>(tup)) && unpack_compare_impl<idxs...>(++curr, tup);
+      }
+      template <class Packet, class Tuple, size_t... idxs>
+      bool unpack_compare(Packet const& pkt, Tuple const& tup, std::index_sequence<idxs...>) {
+        return unpack_compare_impl<idxs...>(pkt.begin(), tup);
+      }
+
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          meta::conjunction<
+            convert::is_castable<Ts, Packet>...
+          >::value
+        >
+      >
+      Packet cast(std::tuple<Ts...> const& tup) {
+        return unpack_convert<Packet>(tup, std::index_sequence_for<Ts...> {});
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          meta::conjunction<
+            convert::is_castable<Ts, Packet>...
+          >::value
+        >
+      >
+      Packet cast(std::tuple<Ts...>&& tup) {
+        return unpack_convert<Packet>(std::move(tup), std::index_sequence_for<Ts...> {});
+      }
+
+      // Equality
+      template <class Packet, class =
+        std::enable_if_t<
+          meta::conjunction<
+            convert::are_comparable<Ts, Packet>...
+          >::value
+        >
+      >
+      bool compare(Packet const& pkt, std::tuple<Ts...> const& tup)
+        noexcept(
+          meta::conjunction<
+            convert::are_nothrow_comparable<Ts, Packet>...
+          >::value
+        )
+      {
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != sizeof...(Ts)) return false;
+        return unpack_compare(pkt, tup, std::index_sequence_for<Ts...> {});
+      }
+    };
+
+    // Specialization for interoperability with std::pair.
+    template <class First, class Second>
+    struct to_dart<std::pair<First, Second>> {
+      // Copy conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<First, Packet>::value
+          &&
+          convert::is_castable<Second, Packet>::value
+        >
+      >
+      Packet cast(std::pair<First, Second> const& pair) {
+        return Packet::make_array(pair.first, pair.second);
+      }
+
+      // Move conversion
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::is_castable<First, Packet>::value
+          &&
+          convert::is_castable<Second, Packet>::value
+        >
+      >
+      Packet cast(std::pair<First, Second>&& pair) {
+        return Packet::make_array(std::move(pair.first), std::move(pair.second));
+      }
+
+      // Equality
+      // Template parameter F is unfortunately necessary here to delay
+      // instantiation of the std::enable_if_t to SFINAE properly
+      template <class Packet, class =
+        std::enable_if_t<
+          convert::are_comparable<First, Packet>::value
+          &&
+          convert::are_comparable<Second, Packet>::value
+        >
+      >
+      bool compare(Packet const& pkt, std::pair<First, Second> const& pair)
+        noexcept(
+          convert::are_nothrow_comparable<First, Packet>::value
+          &&
+          convert::are_nothrow_comparable<Second, Packet>::value
+        )
+      {
+        // Try to short-circuit
+        if (!pkt.is_array()) return false;
+        else if (pkt.size() != 2U) return false;
+
+        // Check the values.
+        typename Packet::view v = pkt;
+        return v[0] == pair.first && v[1] == pair.second;
+      }
+    };
+
+    template <class Duration>
+    struct to_dart<std::chrono::time_point<std::chrono::system_clock, Duration>> {
+      using sys_time_point = std::chrono::time_point<std::chrono::system_clock, Duration>;
+
+      std::string convert(sys_time_point tp) {
+        std::ostringstream oss;
+        std::time_t gmt = std::chrono::system_clock::to_time_t(tp);
+        oss << std::put_time(std::localtime(&gmt), "%FT%TZ");
+        return oss.str();
+      }
+
+      // Copy conversion
+      template <class Packet>
+      Packet cast(sys_time_point tp) {
+        return Packet::make_string(convert(tp));
+      }
+
+      // Equality
+      template <class Packet>
+      bool compare(Packet const& pkt, sys_time_point tp) {
+        return pkt == convert(tp);
+      }
+    };
+
+    // Bizzarely useful in some meta-programming situations.
+    template <class T, T val>
+    struct to_dart<std::integral_constant<T, val>> {
+      // Conversion
+      template <class Packet>
+      Packet cast(std::integral_constant<T, val>) {
+        return convert::cast<Packet>(val);
+      }
+
+      // Equality
+      template <class Packet>
+      bool compare(Packet const& pkt, std::integral_constant<T, val>) {
+        return pkt == convert::cast<Packet>(val);
+      }
+    };
+
+  }
+
+}
+
+#endif

--- a/include/dart/heap/api.tcc
+++ b/include/dart/heap/api.tcc
@@ -26,42 +26,16 @@ namespace dart {
   }
 
   template <template <class> class RefCount>
+  template <class T, class EnableIf>
+  basic_heap<RefCount>& basic_heap<RefCount>::operator =(T&& other) & {
+    *this = convert::cast<basic_heap>(std::forward<T>(other));
+    return *this;
+  }
+
+  template <template <class> class RefCount>
   template <class KeyType, class EnableIf>
   basic_heap<RefCount> basic_heap<RefCount>::operator [](KeyType const& identifier) const {
     return get(identifier);
-  }
-
-  template <template <class> class RefCount>
-  template <template <class> class OtherRC>
-  bool basic_heap<RefCount>::operator ==(basic_heap<OtherRC> const& other) const noexcept {
-    // Check if we're comparing against ourselves.
-    // Cast is necessary to ensure validity if we're comparing
-    // against a different refcounter.
-    if (static_cast<void const*>(this) == static_cast<void const*>(&other)) return true;
-
-    // Check if we're even the same type.
-    if (is_null() && other.is_null()) return true;
-    else if (get_type() != other.get_type()) return false;
-
-    // Defer to our underlying representation.
-    return shim::visit([] (auto& lhs, auto& rhs) {
-      using Lhs = std::decay_t<decltype(lhs)>;
-      using Rhs = std::decay_t<decltype(rhs)>;
-
-      // Have to compare through pointers here, and we make the decision purely off of the
-      // ability to dereference the incoming type to try to allow compatibility with custom
-      // external smart-pointers that otherwise conform to the std::shared_ptr interface.
-      auto comparator = detail::typeless_comparator {};
-      auto& lval = detail::maybe_dereference(lhs, meta::is_dereferenceable<Lhs> {});
-      auto& rval = detail::maybe_dereference(rhs, meta::is_dereferenceable<Rhs> {});
-      return comparator(lval, rval);
-    }, data, other.data);
-  }
-
-  template <template <class> class RefCount>
-  template <template <class> class OtherRC>
-  bool basic_heap<RefCount>::operator !=(basic_heap<OtherRC> const& other) const noexcept {
-    return !(*this == other);
   }
 
   template <template <class> class RefCount>

--- a/include/dart/meta.h
+++ b/include/dart/meta.h
@@ -174,6 +174,15 @@ namespace dart {
     template <class T, std::ptrdiff_t extent>
     struct is_span<gsl::span<T, extent>> : std::true_type {};
 
+    template <class T>
+    struct is_std_smart_ptr : std::false_type {};
+    template <class T, class Del>
+    struct is_std_smart_ptr<std::unique_ptr<T, Del>> : std::true_type {};
+    template <class T>
+    struct is_std_smart_ptr<std::shared_ptr<T>> : std::true_type {};
+    template <class T>
+    struct is_std_smart_ptr<std::weak_ptr<T>> : std::true_type {};
+
     template <size_t pos>
     struct priority_tag : priority_tag<pos - 1> {};
     template <>

--- a/include/dart/object.tcc
+++ b/include/dart/object.tcc
@@ -35,9 +35,8 @@ namespace dart {
   template <class Object>
   template <class Arg,
     std::enable_if_t<
-      !meta::is_specialization_of<
-        Arg,
-        dart::basic_object
+      !detail::is_wrapper_type<
+        std::decay_t<Arg>
       >::value
       &&
       std::is_convertible<

--- a/include/dart/operators.tcc
+++ b/include/dart/operators.tcc
@@ -4,438 +4,50 @@
 /*----- Local Includes -----*/
 
 #include "common.h"
+#include "conversion_traits.h"
 
 /*----- Function Definitions -----*/
 
-// I apologize for this whole file.
-// I'm not usually a macro kind of guy, but this is one of those rare
-// situations where the code would actually be WORSE without the macros.
-// It doesn't help that the Dart API surface is so large
 namespace dart {
 
-  /*----- Wrapper Equality Operations -----*/
-
-  // Macro defines symmetric equality comparison operators (across implementation types)
-  // for a given pair of wrapper templates.
-#define DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(lhs_wrapper, rhs_wrapper)                                  \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC,                                                                       \
-            template <template <class> class> class LhsPacket,                                                  \
-            template <template <class> class> class RhsPacket>                                                  \
-  constexpr bool                                                                                                \
-  operator ==(lhs_wrapper<LhsPacket<LhsRC>> const&, rhs_wrapper<RhsPacket<RhsRC>> const&) {                     \
-    return false;                                                                                               \
-  }                                                                                                             \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC,                                                                       \
-            template <template <class> class> class LhsPacket,                                                  \
-            template <template <class> class> class RhsPacket>                                                  \
-  constexpr bool                                                                                                \
-  operator !=(lhs_wrapper<LhsPacket<LhsRC>> const& lhs, rhs_wrapper<RhsPacket<RhsRC>> const& rhs) {             \
-    return !(lhs == rhs);                                                                                       \
-  }                                                                                                             \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC,                                                                       \
-            template <template <class> class> class LhsPacket,                                                  \
-            template <template <class> class> class RhsPacket>                                                  \
-  constexpr bool                                                                                                \
-  operator ==(rhs_wrapper<LhsPacket<LhsRC>> const&, lhs_wrapper<RhsPacket<RhsRC>> const&) {                     \
-    return false;                                                                                               \
-  }                                                                                                             \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC,                                                                       \
-            template <template <class> class> class LhsPacket,                                                  \
-            template <template <class> class> class RhsPacket>                                                  \
-  constexpr bool                                                                                                \
-  operator !=(rhs_wrapper<LhsPacket<LhsRC>> const& rhs, lhs_wrapper<RhsPacket<RhsRC>> const& lhs) {             \
-    return !(rhs == lhs);                                                                                       \
-  }
-
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_object, basic_array);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_object, basic_string);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_object, basic_number);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_object, basic_flag);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_object, basic_null);
-
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_array, basic_string);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_array, basic_number);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_array, basic_flag);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_array, basic_null);
-
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_string, basic_number);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_string, basic_flag);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_string, basic_null);
-
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_number, basic_flag);
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_number, basic_null);
-
-  DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS(basic_flag, basic_null);
-#undef DART_DEFINE_CROSS_WRAPPER_EQUALITY_OPERATORS
-
-  // Macro defines symmetric equality comparison operators for a given wrapper type and its
-  // implementation type.
-  // XXX: Would be nice to be able to compare across packet types here, but these templates
-  // aren't otherwise constrained, and I'm afraid it would be too wide open.
-#define DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(wrapper)                                                  \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC, template <template <class> class> class Packet>                       \
-  bool operator ==(wrapper<Packet<LhsRC>> const& lhs, Packet<RhsRC> const& rhs) {                               \
-    return lhs.dynamic() == rhs;                                                                                \
-  }                                                                                                             \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC, template <template <class> class> class Packet>                       \
-  bool operator !=(wrapper<Packet<LhsRC>> const& lhs, Packet<RhsRC> const& rhs) {                               \
-    return !(lhs == rhs);                                                                                       \
-  }                                                                                                             \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC, template <template <class> class> class Packet>                       \
-  bool operator ==(Packet<LhsRC> const& rhs, wrapper<Packet<RhsRC>> const& lhs) {                               \
-    return rhs == lhs.dynamic();                                                                                \
-  }                                                                                                             \
-  template <template <class> class LhsRC,                                                                       \
-            template <class> class RhsRC, template <template <class> class> class Packet>                       \
-  bool operator !=(Packet<LhsRC> const& rhs, wrapper<Packet<RhsRC>> const& lhs) {                               \
-    return !(rhs == lhs);                                                                                       \
-  }
-
-  DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(basic_object);
-  DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(basic_array);
-  DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(basic_string);
-  DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(basic_number);
-  DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(basic_flag);
-  DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS(basic_null);
-#undef DART_DEFINE_WRAPPER_PACKET_EQUALITY_OPERATORS
-
-  // Macro defines symmetric equality comparison operators for a given pair of wrapper and
-  // machine type.
-#define DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS(wrapper, machine_type)                                   \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator ==(wrapper<Packet<RefCount>> const& lhs, machine_type rhs) {                                    \
-    return lhs.dynamic() == rhs;                                                                                \
-  }                                                                                                             \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator !=(wrapper<Packet<RefCount>> const& lhs, machine_type rhs) {                                    \
-    return !(lhs == rhs);                                                                                       \
-  }                                                                                                             \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator ==(machine_type rhs, wrapper<Packet<RefCount>> const& lhs) {                                    \
-    return rhs == lhs.dynamic();                                                                                \
-  }                                                                                                             \
-  template <template <class> class RefCount, template <template <class> class> class Packet>                    \
-  bool operator !=(machine_type rhs, wrapper<Packet<RefCount>> const& lhs) {                                    \
-    return !(rhs == lhs);                                                                                       \
-  }
-
-  DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS(basic_string, shim::string_view);
-  DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS(basic_number, int64_t);
-  DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS(basic_number, double);
-  DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS(basic_flag, bool);
-  DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS(basic_null, std::nullptr_t);
-#undef DART_DEFINE_WRAPPER_MACHINE_EQUALITY_OPERATORS
-
-  // Macro defines an std::ostream redirection operator for a wrapper type.
-#if DART_HAS_RAPIDJSON
-#define DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(wrapper)                                                           \
-  template <class Packet>                                                                                       \
-  std::ostream& operator <<(std::ostream& out, wrapper<Packet> const& dart) {                                   \
-    out << dart.to_json();                                                                                      \
-    return out;                                                                                                 \
-  }
-
-  DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(basic_object);
-  DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(basic_array);
-  DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(basic_string);
-  DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(basic_number);
-  DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(basic_flag);
-  DART_DEFINE_WRAPPER_OSTREAM_OPERATOR(basic_null);
-#undef DART_DEFINE_WRAPPER_OSTREAM_OPERATOR
-#endif
-
-  /*----- Cross-type Equality Operators -----*/
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator ==(basic_buffer<LhsRC> const& lhs, basic_heap<RhsRC> const& rhs) {
-    // Make sure they're at least of the same type.
-    if (lhs.get_type() != rhs.get_type()) return false;
-
-    // Perform type specific comparisons.
-    switch (lhs.get_type()) {
-      case detail::type::object:
-        {
-          // Bail early if we can.
-          if (lhs.size() != rhs.size()) return false;
-
-          // Ouch.
-          // Iterates over rhs and looks up into lhs because lhs is the finalized
-          // object and lookups should be significantly faster on it.
-          typename basic_heap<RhsRC>::iterator k, v;
-          std::tie(k, v) = rhs.kvbegin();
-          while (v != rhs.end()) {
-            if (*v != lhs[*k]) return false;
-            ++k, ++v;
-          }
-          return true;
-        }
-      case detail::type::array:
-        {
-          // Bail early if we can.
-          if (lhs.size() != rhs.size()) return false;
-
-          // Ouch.
-          for (auto i = 0U; i < lhs.size(); ++i) {
-            if (lhs[i] != rhs[i]) return false;
-          }
-          return true;
-        }
-      case detail::type::string:
-        return lhs.strv() == rhs.strv();
-      case detail::type::integer:
-        return lhs.integer() == rhs.integer();
-      case detail::type::decimal:
-        return lhs.decimal() == rhs.decimal();
-      case detail::type::boolean:
-        return lhs.boolean() == rhs.boolean();
-      default:
-        DART_ASSERT(lhs.is_null());
-        return true;
-    }
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator ==(basic_heap<LhsRC> const& lhs, basic_buffer<RhsRC> const& rhs) {
-    return rhs == lhs;
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator ==(basic_buffer<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
-    return shim::visit([&] (auto& v) { return lhs == v; }, rhs.impl);
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator ==(basic_heap<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
-    return shim::visit([&] (auto& v) { return lhs == v; }, rhs.impl);
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator !=(basic_buffer<LhsRC> const& lhs, basic_heap<RhsRC> const& rhs) {
-    return !(lhs == rhs);
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator !=(basic_heap<LhsRC> const& lhs, basic_buffer<RhsRC> const& rhs) {
-    return !(lhs == rhs);
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator !=(basic_buffer<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
-    return !(lhs == rhs);
-  }
-
-  template <template <class> class LhsRC, template <class> class RhsRC>
-  bool operator !=(basic_heap<LhsRC> const& lhs, basic_packet<RhsRC> const& rhs) {
-    return !(lhs == rhs);
-  }
-
-  /*----- String Comparison -----*/
-
-#define DART_DEFINE_PACKET_STRING_EQUALITY_OPERATORS(packet)                                                    \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(packet<RefCount> const& dart, shim::string_view str) noexcept {                              \
-    if (!dart.is_str() || dart.size() != static_cast<size_t>(str.size())) return false;                         \
-    return str == dart.str();                                                                                   \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(shim::string_view str, packet<RefCount> const& dart) noexcept {                              \
-    return dart == str;                                                                                         \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(packet<RefCount> const& dart, char const* str) noexcept {                                    \
-    return dart == shim::string_view(str);                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(char const* str, packet<RefCount> const& dart) noexcept {                                    \
-    return shim::string_view(str) == dart;                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(packet<RefCount> const& dart, shim::string_view str) noexcept {                              \
-    return !(dart == str);                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(shim::string_view str, packet<RefCount> const& dart) noexcept {                              \
-    return !(str == dart);                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(packet<RefCount> const& dart, char const* str) noexcept {                                    \
-    return !(dart == shim::string_view(str));                                                                   \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(char const* str, packet<RefCount> const& dart) noexcept {                                    \
-    return !(shim::string_view(str) == dart);                                                                   \
-  }
-
-  DART_DEFINE_PACKET_STRING_EQUALITY_OPERATORS(basic_heap);
-  DART_DEFINE_PACKET_STRING_EQUALITY_OPERATORS(basic_buffer);
-  DART_DEFINE_PACKET_STRING_EQUALITY_OPERATORS(basic_packet);
-#undef DART_DEFINE_PACKET_STRING_EQUALITY_OPERATORS
-
-  /*----- Decimal Comparison -----*/
-
-#define DART_DEFINE_PACKET_DCM_EQUALITY_OPERATORS(packet)                                                       \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      std::is_floating_point<T>::value                                                                          \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator ==(packet<RefCount> const& dart, T val) noexcept {                                              \
-    return dart.is_decimal() ? dart.decimal() == val : false;                                                   \
-  }                                                                                                             \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      std::is_floating_point<T>::value                                                                          \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator ==(T val, packet<RefCount> const& dart) noexcept {                                              \
-    return dart == val;                                                                                         \
-  }                                                                                                             \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      std::is_floating_point<T>::value                                                                          \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator !=(packet<RefCount> const& dart, T val) noexcept {                                              \
-    return !(dart == val);                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      std::is_floating_point<T>::value                                                                          \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator !=(T val, packet<RefCount> const& dart) noexcept {                                              \
-    return !(val == dart);                                                                                      \
-  }
-  
-  DART_DEFINE_PACKET_DCM_EQUALITY_OPERATORS(basic_heap);
-  DART_DEFINE_PACKET_DCM_EQUALITY_OPERATORS(basic_buffer);
-  DART_DEFINE_PACKET_DCM_EQUALITY_OPERATORS(basic_packet);
-#undef DART_DEFINE_PACKET_DCM_EQUALITY_OPERATORS
-
-  /*----- Integer Comparison -----*/
-
   namespace detail {
-    template <class T>
-    struct is_integral_num :
+    template <class Lhs, class Rhs>
+    struct dart_comparison_constraints :
       meta::conjunction<
-        std::is_integral<T>,
-        meta::negation<
-          std::is_same<
-            std::decay_t<T>,
-            bool
-          >
-        >
+        meta::disjunction<
+          detail::is_dart_api_type<std::decay_t<Lhs>>,
+          detail::is_dart_api_type<std::decay_t<Rhs>>
+        >,
+        convert::are_comparable<Lhs, Rhs>
       >
     {};
   }
 
-#define DART_DEFINE_PACKET_INT_EQUALITY_OPERATORS(packet)                                                       \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      detail::is_integral_num<T>::value                                                                         \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator ==(packet<RefCount> const& dart, T const& val) noexcept {                                       \
-    return dart::shim::compose_together(                                                                        \
-      [] (auto& d, auto v, std::true_type) {                                                                    \
-        return d.is_integer() ? static_cast<uint64_t>(d.integer()) == v : false;                                \
-      },                                                                                                        \
-      [] (auto& d, auto v, std::false_type) {                                                                   \
-        return d.is_integer() ? d.integer() == v : false;                                                       \
-      }                                                                                                         \
-    )(dart, val, std::is_unsigned<T> {});                                                                       \
-  }                                                                                                             \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      detail::is_integral_num<T>::value                                                                         \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator ==(T const& val, packet<RefCount> const& dart) noexcept {                                       \
-    return dart == val;                                                                                         \
-  }                                                                                                             \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      detail::is_integral_num<T>::value                                                                         \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator !=(packet<RefCount> const& dart, T const& val) noexcept {                                       \
-    return !(dart == val);                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount, class T, class =                                                   \
-    std::enable_if_t<                                                                                           \
-      detail::is_integral_num<T>::value                                                                         \
-    >                                                                                                           \
-  >                                                                                                             \
-  bool operator !=(T const& val, packet<RefCount> const& dart) noexcept {                                       \
-    return !(val == dart);                                                                                      \
+  template <class Lhs, class Rhs, class =
+    std::enable_if_t<
+      detail::dart_comparison_constraints<Lhs, Rhs>::value
+    >
+  >
+  bool operator ==(Lhs const& lhs, Rhs const& rhs) noexcept(convert::are_nothrow_comparable<Lhs, Rhs>::value) {
+    return convert::compare(lhs, rhs);
   }
 
-  DART_DEFINE_PACKET_INT_EQUALITY_OPERATORS(basic_heap);
-  DART_DEFINE_PACKET_INT_EQUALITY_OPERATORS(basic_buffer);
-  DART_DEFINE_PACKET_INT_EQUALITY_OPERATORS(basic_packet);
-#undef DART_DEFINE_PACKET_INT_EQUALITY_OPERATORS
-
-  /*----- Boolean Comparison -----*/
-
-#define DART_DEFINE_PACKET_BOOL_EQUALITY_OPERATORS(packet)                                                      \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(packet<RefCount> const& dart, bool val) noexcept {                                           \
-    return dart.is_boolean() ? dart.boolean() == val : false;                                                   \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(bool val, packet<RefCount> const& dart) noexcept {                                           \
-    return dart == val;                                                                                         \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(packet<RefCount> const& dart, bool val) noexcept {                                           \
-    return !(dart == val);                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(bool val, packet<RefCount> const& dart) noexcept {                                           \
-    return !(val == dart);                                                                                      \
+  template <class Lhs, class Rhs, class =
+    std::enable_if_t<
+      detail::dart_comparison_constraints<Lhs, Rhs>::value
+    >
+  >
+  bool operator !=(Lhs const& lhs, Rhs const& rhs) noexcept(convert::are_nothrow_comparable<Lhs, Rhs>::value) {
+    return !(lhs == rhs);
   }
 
-  DART_DEFINE_PACKET_BOOL_EQUALITY_OPERATORS(basic_heap);
-  DART_DEFINE_PACKET_BOOL_EQUALITY_OPERATORS(basic_buffer);
-  DART_DEFINE_PACKET_BOOL_EQUALITY_OPERATORS(basic_packet);
-#undef DART_DEFINE_PACKET_BOOL_EQUALITY_OPERATORS
-
-  /*----- Null Comparison -----*/
-
-#define DART_DEFINE_PACKET_NULL_EQUALITY_OPERATORS(packet)                                                      \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(packet<RefCount> const& dart, std::nullptr_t) noexcept {                                     \
-    return dart.is_null();                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator ==(std::nullptr_t, packet<RefCount> const& dart) noexcept {                                     \
-    return dart.is_null();                                                                                      \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(packet<RefCount> const& dart, std::nullptr_t) noexcept {                                     \
-    return !dart.is_null();                                                                                     \
-  }                                                                                                             \
-  template <template <class> class RefCount>                                                                    \
-  bool operator !=(std::nullptr_t, packet<RefCount> const& dart) noexcept {                                     \
-    return !dart.is_null();                                                                                     \
-  }
-
-  DART_DEFINE_PACKET_NULL_EQUALITY_OPERATORS(basic_heap);
-  DART_DEFINE_PACKET_NULL_EQUALITY_OPERATORS(basic_buffer);
-  DART_DEFINE_PACKET_NULL_EQUALITY_OPERATORS(basic_packet);
-#undef DART_DEFINE_PACKET_NULL_EQUALITY_OPERATORS
-
-  // Lazy, but effective.
 #if DART_HAS_RAPIDJSON
-  template <template <template <class> class> class Packet, template <class> class RefCount>
-  std::ostream& operator <<(std::ostream& out, Packet<RefCount> const& dart) {
+  template <class Packet, class =
+    std::enable_if_t<
+      detail::is_dart_api_type<Packet>::value
+    >
+  >
+  std::ostream& operator <<(std::ostream& out, Packet const& dart) {
     out << dart.to_json();
     return out;
   }

--- a/include/dart/packet/api.tcc
+++ b/include/dart/packet/api.tcc
@@ -10,6 +10,13 @@
 namespace dart {
 
   template <template <class> class RefCount>
+  template <class T, class EnableIf>
+  basic_packet<RefCount>& basic_packet<RefCount>::operator =(T&& other) & {
+    get_heap() = std::forward<T>(other);
+    return *this;
+  }
+
+  template <template <class> class RefCount>
   template <class KeyType, class EnableIf>
   basic_packet<RefCount> basic_packet<RefCount>::operator [](KeyType const& identifier) const& {
     return get(identifier);
@@ -19,32 +26,6 @@ namespace dart {
   template <class KeyType, class EnableIf>
   basic_packet<RefCount>&& basic_packet<RefCount>::operator [](KeyType const& identifier) && {
     return std::move(*this).get(identifier);
-  }
-
-  template <template <class> class RefCount>
-  bool basic_packet<RefCount>::operator ==(basic_packet const& other) const noexcept {
-    return this->operator ==<RefCount>(other);
-  }
-
-  template <template <class> class RefCount>
-  template <template <class> class OtherRC>
-  bool basic_packet<RefCount>::operator ==(basic_packet<OtherRC> const& other) const noexcept {
-    // Check if we're comparing against ourselves.
-    // Cast is necessary to ensure validity if we're comparing
-    // against a different refcounter.
-    if (static_cast<void const*>(this) == static_cast<void const*>(&other)) return true;
-    return shim::visit([] (auto& lhs, auto& rhs) { return lhs == rhs; }, impl, other.impl);
-  }
-
-  template <template <class> class RefCount>
-  bool basic_packet<RefCount>::operator !=(basic_packet const& other) const noexcept {
-    return this->operator !=<RefCount>(other);
-  }
-
-  template <template <class> class RefCount>
-  template <template <class> class OtherRC>
-  bool basic_packet<RefCount>::operator !=(basic_packet<OtherRC> const& other) const noexcept {
-    return !(*this == other);
   }
 
   template <template <class> class RefCount>

--- a/include/dart/support/optional.h
+++ b/include/dart/support/optional.h
@@ -324,6 +324,10 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator ==(optional<T> const& lhs, optional<U> const& rhs) {
@@ -334,6 +338,10 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator !=(optional<T> const& lhs, optional<U> const& rhs) {
@@ -344,6 +352,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator ==(optional<T> const& lhs, U const& rhs) {
@@ -353,6 +363,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_comparable<T const&, U const>::value
+      &&
+      std::is_convertible<T, U>::value
     >
   >
   bool operator ==(T const& lhs, optional<U> const& rhs) {
@@ -361,6 +373,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator !=(optional<T> const& lhs, U const& rhs) {
@@ -369,6 +383,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_comparable<T const&, U const>::value
+      &&
+      std::is_convertible<T, U>::value
     >
   >
   bool operator !=(T const& lhs, optional<U> const& rhs) {
@@ -399,6 +415,10 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_lt_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator <(optional<T> const& lhs, optional<U> const& rhs) {
@@ -409,6 +429,10 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_lte_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator <=(optional<T> const& lhs, optional<U> const& rhs) {
@@ -421,6 +445,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_lt_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator <(optional<T> const& lhs, U const& rhs) {
@@ -430,6 +456,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_lt_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
     >
   >
   bool operator <(T const& lhs, optional<U> const& rhs) {
@@ -439,6 +467,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_lte_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator <=(optional<T> const& lhs, U const& rhs) {
@@ -448,6 +478,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_lte_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
     >
   >
   bool operator <=(T const& lhs, optional<U> const& rhs) {
@@ -477,6 +509,10 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_gt_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator >(optional<T> const& lhs, optional<U> const& rhs) {
@@ -487,6 +523,10 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_gte_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator >=(optional<T> const& lhs, optional<U> const& rhs) {
@@ -499,6 +539,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_gt_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator >(optional<T> const& lhs, U const& rhs) {
@@ -508,6 +550,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_gt_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
     >
   >
   bool operator >(T const& lhs, optional<U> const& rhs) {
@@ -517,6 +561,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_gte_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<U, T>::value
     >
   >
   bool operator >=(optional<T> const& lhs, U const& rhs) {
@@ -526,6 +572,8 @@ namespace dart {
   template <class T, class U, class =
     std::enable_if_t<
       meta::are_gte_comparable<T const&, U const&>::value
+      &&
+      std::is_convertible<T, U>::value
     >
   >
   bool operator >=(T const& lhs, optional<U> const& rhs) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,10 +12,11 @@ endif ()
 
 # Setup targets for our unit tests.
 add_executable(unit_tests
-  type_unit_tests.cc obj_unit_tests.cc arr_unit_tests.cc
-  str_unit_tests.cc int_unit_tests.cc dcm_unit_tests.cc
-  bool_unit_tests.cc null_unit_tests.cc iteration_unit_tests.cc
-  ptr_unit_tests.cc misc_unit_tests.cc optional_unit_tests.cc
+  operator_unit_tests.cc type_unit_tests.cc
+  obj_unit_tests.cc arr_unit_tests.cc str_unit_tests.cc
+  int_unit_tests.cc dcm_unit_tests.cc bool_unit_tests.cc
+  null_unit_tests.cc iteration_unit_tests.cc ptr_unit_tests.cc
+  misc_unit_tests.cc optional_unit_tests.cc
   string_view_unit_tests.cc view_unit_tests.cc $<TARGET_OBJECTS:catch>
 )
 

--- a/test/operator_unit_tests.cc
+++ b/test/operator_unit_tests.cc
@@ -1,0 +1,486 @@
+/*----- System Includes -----*/
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <unordered_set>
+#include <unordered_map>
+
+/*----- Local Includes -----*/
+
+#include "dart_tests.h"
+
+/*----- Type Declarations -----*/
+
+struct my_string {
+  my_string(char const* val) : val(val) {}
+
+  bool operator ==(my_string const& other) const {
+    return val == other.val;
+  }
+  bool operator !=(my_string const& other) const {
+    return !(*this == other);
+  }
+  bool operator <(my_string const& other) const {
+    return val < other.val;
+  }
+
+  std::string val;
+};
+
+namespace dart {
+  namespace convert {
+    template <>
+    struct to_dart<my_string> {
+      template <class Packet>
+      Packet cast(my_string const& str) {
+        return Packet::make_string(str.val);
+      }
+      template <class Packet>
+      bool compare(Packet const& pkt, my_string const& str) noexcept {
+        return pkt.is_str() && pkt.strv() == str.val;
+      }
+    };
+  }
+}
+
+namespace std {
+  template <>
+  struct hash<my_string> {
+    size_t operator ()(my_string const& str) const noexcept {
+      return std::hash<std::string> {}(str.val);
+    }
+  };
+}
+
+namespace {
+  using clock = std::chrono::system_clock;
+}
+
+/*----- Function Implementations -----*/
+
+SCENARIO("mutable dart types can be assigned to from many types", "[operator unit]") {
+  GIVEN("a default constructed generic type") {
+    dart::mutable_api_test([] (auto tag, auto idx) {
+      using pkt = typename decltype(tag)::type;
+      using svec = std::vector<my_string>;
+      using map = std::map<my_string, my_string>;
+      using mmap = std::multimap<my_string, my_string>;
+      using umap = std::unordered_map<std::string, my_string>;
+      using ummap = std::unordered_multimap<my_string, my_string>;
+      using vec = std::vector<dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+      using deq = std::deque<dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+      using arr = std::array<dart::shim::optional<dart::shim::variant<int, double, my_string>>, 4>;
+      using lst = std::list<dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+      using flst = std::forward_list<dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+      using set = std::set<my_string>;
+      using mset = std::multiset<my_string>;
+      using pair = std::pair<my_string, my_string>;
+      using span = gsl::span<my_string const>;
+
+      // Get a default constructed instance.
+      pkt val;
+      REQUIRE(val.is_null());
+
+      // Test std::vector, std::variant, and std::optional assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a vector", idx) {
+        auto v = vec {1337, 3.14159, "there are many like it, but this vector is mine", dart::shim::nullopt};
+        val = v;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == v);
+          REQUIRE(v == val);
+          static_assert(noexcept(v == val), "Dart is misconfigured");
+          static_assert(noexcept(val == v), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<vec, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::deque, std::variant, and std::optional assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a deque", idx) {
+        auto d = deq {1337, 3.14159, "there are many like it, but this deque is mine", dart::shim::nullopt};
+        val = d;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == d);
+          REQUIRE(d == val);
+          static_assert(noexcept(d == val), "Dart is misconfigured");
+          static_assert(noexcept(val == d), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<deq, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::array, std::variant, and std::optional assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from an array", idx) {
+        auto a = arr {{1337, 3.14159, "there are many like it, but this array is mine", dart::shim::nullopt}};
+        val = a;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == a);
+          REQUIRE(a == val);
+          static_assert(noexcept(a == val), "Dart is misconfigured");
+          static_assert(noexcept(val == a), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<arr, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::list, std::variant, and std::optional assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a list", idx) {
+        auto l = lst {1337, 3.14159, "there are many like it, but this list is mine", dart::shim::nullopt};
+        val = l;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == l);
+          REQUIRE(l == val);
+          static_assert(noexcept(l == val), "Dart is misconfigured");
+          static_assert(noexcept(val == l), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<lst, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::forward_list, std::variant, and std::optional assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a forward list", idx) {
+        auto fl = flst {1337, 3.14159, "there are many like it, but this list is mine", dart::shim::nullopt};
+        val = fl;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == fl);
+          REQUIRE(fl == val);
+          static_assert(noexcept(fl == val), "Dart is misconfigured");
+          static_assert(noexcept(val == fl), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<flst, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::map assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a map", idx) {
+        auto m = map {{"hello", "world"}, {"yes", "no"}};
+        val = m;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == m);
+          REQUIRE(m == val);
+          static_assert(noexcept(m == val), "Dart is misconfigured");
+          static_assert(noexcept(val == m), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<map, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::unordered_map assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from an unordered map", idx) {
+        auto um = umap {{"hello", "world"}, {"yes", "no"}};
+        val = um;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == um);
+          REQUIRE(um == val);
+          static_assert(noexcept(um == val), "Dart is misconfigured");
+          static_assert(noexcept(val == um), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<umap, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::multimap assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a multimap", idx) {
+        auto m = mmap {{"hello", "world"}, {"yes", "no"}};
+        val = m;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == m);
+          REQUIRE(m == val);
+          static_assert(noexcept(m == val), "Dart is misconfigured");
+          static_assert(noexcept(val == m), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<mmap, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::multimap assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a multimap", idx) {
+        auto um = ummap {{"hello", "world"}, {"yes", "no"}};
+        val = um;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == um);
+          REQUIRE(um == val);
+          static_assert(noexcept(um == val), "Dart is misconfigured");
+          static_assert(noexcept(val == um), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<ummap, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::set assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a set", idx) {
+        auto s = set {"dark side", "meddle", "the wall", "animals"};
+        val = s;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == s);
+          REQUIRE(s == val);
+          static_assert(noexcept(s == val), "Dart is misconfigured");
+          static_assert(noexcept(val == s), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<set, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::multiset assignment/comparison
+      DYNAMIC_WHEN("the value is assigned from a multiset", idx) {
+        auto m = mset {"dark side", "meddle", "meddle", "the wall", "animals"};
+        val = m;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == m);
+          REQUIRE(m == val);
+          static_assert(noexcept(m == val), "Dart is misconfigured");
+          static_assert(noexcept(val == m), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<mset, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from a pair", idx) {
+        auto p = pair {"first", "second"};
+        val = p;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == p);
+          REQUIRE(p == val);
+          static_assert(noexcept(p == val), "Dart is misconfigured");
+          static_assert(noexcept(val == p), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<pair, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from a span", idx) {
+        auto v = svec {"hello", "world", "yes", "no", "stop", "go"};
+        span s = v;
+        val = s;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == s);
+          REQUIRE(s == val);
+          static_assert(noexcept(s == val), "Dart is misconfigured");
+          static_assert(noexcept(val == s), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<span, pkt>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from a time point", idx) {
+        auto t = clock::now();
+        val = t;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == t);
+          REQUIRE(t == val);
+          static_assert(!noexcept(t == val), "Dart is misconfigured");
+          static_assert(!noexcept(val == t), "Dart is misconfigured");
+          static_assert(!dart::convert::are_nothrow_comparable<clock::time_point, pkt>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+
+  GIVEN("a default constructed object type") {
+    dart::mutable_object_api_test([] (auto tag, auto idx) {
+      using object = typename decltype(tag)::type;
+      using map = std::map<std::string, dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+      using umap =
+          std::unordered_map<std::string, dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+
+      // Get a default constructed instance.
+      object val;
+      REQUIRE(val.is_object());
+      REQUIRE(val.empty());
+
+      // Test std::map assignment/comparison.
+      DYNAMIC_WHEN("the value is assigned from a map", idx) {
+        auto m = map {{"pi", 3.14159}, {"truth", 42}, {"best album", "dark side"}};
+        val = m;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == m);
+          REQUIRE(m == val);
+          static_assert(noexcept(m == val), "Dart is misconfigured");
+          static_assert(noexcept(val == m), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<map, object>::value, "Dart is misconfigured");
+        }
+      }
+
+      // Test std::unordered_map assignment/comparison.
+      DYNAMIC_WHEN("the value is assigned from an unordered map", idx) {
+        auto m = umap {{"pi", 3.14159}, {"truth", 42}, {"best album", "dark side"}};
+        val = m;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == m);
+          REQUIRE(m == val);
+          static_assert(noexcept(m == val), "Dart is misconfigured");
+          static_assert(noexcept(val == m), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<umap, object>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+
+  GIVEN("a default constructed array type") {
+    dart::mutable_array_api_test([] (auto tag, auto idx) {
+      using array = typename decltype(tag)::type;
+      using vec = std::vector<dart::shim::optional<dart::shim::variant<int, double, my_string>>>;
+      using arr = std::array<dart::shim::optional<dart::shim::variant<int, double, my_string>>, 4>;
+
+      array val;
+      REQUIRE(val.is_array());
+      REQUIRE(val.empty());
+
+      DYNAMIC_WHEN("the value is assigned from a vector", idx) {
+        auto v = vec {1337, 3.14159, "there are many like it, but this vector is mine", dart::shim::nullopt};
+        val = v;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == v);
+          REQUIRE(v == val);
+          static_assert(noexcept(v == val), "Dart is misconfigured");
+          static_assert(noexcept(val == v), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<vec, array>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from an array", idx) {
+        auto v = arr {{1337, 3.14159, "there are many like it, but this array is mine", dart::shim::nullopt}};
+        val = v;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == v);
+          REQUIRE(v == val);
+          static_assert(noexcept(v == val), "Dart is misconfigured");
+          static_assert(noexcept(val == v), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<arr, array>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+
+  GIVEN("a default constructed string") {
+    dart::mutable_string_api_test([] (auto tag, auto idx) {
+      using string = typename decltype(tag)::type;
+
+      string val;
+      REQUIRE(val.is_str());
+      REQUIRE(val.empty());
+
+      DYNAMIC_WHEN("the value is assigned from a string literal", idx) {
+        auto* str = "hello world";
+        val = str;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(str == val);
+          REQUIRE(val == str);
+          static_assert(noexcept(str == val), "Dart is misconfigured");
+          static_assert(noexcept(val == str), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<char const*, string>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from a std::string", idx) {
+        std::string str = "hello world";
+        val = str;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(str == val);
+          REQUIRE(val == str);
+          static_assert(noexcept(str == val), "Dart is misconfigured");
+          static_assert(noexcept(val == str), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<std::string, string>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from a std::string_view", idx) {
+        dart::shim::string_view str = "hello world";
+        val = str;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(str == val);
+          REQUIRE(val == str);
+          static_assert(noexcept(str == val), "Dart is misconfigured");
+          static_assert(noexcept(val == str), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<dart::shim::string_view, string>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+
+  GIVEN("a default constructed number") {
+    dart::mutable_number_api_test([] (auto tag, auto idx) {
+      using number = typename decltype(tag)::type;
+
+      number val;
+      REQUIRE(val.is_numeric());
+      REQUIRE(val == 0);
+
+      DYNAMIC_WHEN("the value is assigned from an integer literal", idx) {
+        val = 1337;
+        val = 1337L;
+        val = 1337U;
+        val = 1337UL;
+        val = 1337LL;
+        val = 1337ULL;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == 1337);
+          REQUIRE(1337 == val);
+          REQUIRE(val == 1337L);
+          REQUIRE(1337L == val);
+          REQUIRE(val == 1337U);
+          REQUIRE(1337U == val);
+          REQUIRE(val == 1337UL);
+          REQUIRE(1337UL == val);
+          REQUIRE(val == 1337LL);
+          REQUIRE(1337LL == val);
+          REQUIRE(val == 1337ULL);
+          REQUIRE(1337ULL == val);
+          static_assert(noexcept(val == 1337), "Dart is misconfigured");
+          static_assert(noexcept(1337 == val), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<int, number>::value, "Dart is misconfigured");
+        }
+      }
+
+      DYNAMIC_WHEN("the value is assigned from a decimal literal", idx) {
+        // We're not testing the float point precision of the platform
+        // so use something that can be precisely represented anywhere.
+        val = 0.5F;
+        val = 0.5;
+        val = 0.5L;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == 0.5F);
+          REQUIRE(0.5F == val);
+          REQUIRE(val == 0.5);
+          REQUIRE(0.5 == val);
+          REQUIRE(val == 0.5L);
+          REQUIRE(0.5L == val);
+          static_assert(noexcept(val == 0.5), "Dart is misconfigured");
+          static_assert(noexcept(0.5 == val), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<double, number>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+
+  GIVEN("a default constructed boolean") {
+    dart::mutable_flag_api_test([] (auto tag, auto idx) {
+      using flag = typename decltype(tag)::type;
+
+      flag val;
+      REQUIRE(val.is_boolean());
+      REQUIRE(val == false);
+
+      DYNAMIC_WHEN("the value is assigned from a bool literal", idx) {
+        val = true;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == true);
+          REQUIRE(true == val);
+          static_assert(noexcept(val == true), "Dart is misconfigured");
+          static_assert(noexcept(true == val), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<bool, flag>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+
+  GIVEN("a default constructed null") {
+    dart::mutable_null_api_test([] (auto tag, auto idx) {
+      using null = typename decltype(tag)::type;
+
+      null val;
+      REQUIRE(val.is_null());
+      REQUIRE(val == null {});
+
+      DYNAMIC_WHEN("the value is assigned from a nullptr literal", idx) {
+        val = nullptr;
+        DYNAMIC_THEN("it takes on the value we expect", idx) {
+          REQUIRE(val == nullptr);
+          REQUIRE(nullptr == val);
+          static_assert(noexcept(val == nullptr), "Dart is misconfigured");
+          static_assert(noexcept(nullptr == val), "Dart is misconfigured");
+          static_assert(dart::convert::are_nothrow_comparable<std::nullptr_t, null>::value, "Dart is misconfigured");
+        }
+      }
+    });
+  }
+}

--- a/test/optional_unit_tests.cc
+++ b/test/optional_unit_tests.cc
@@ -26,6 +26,7 @@ SCENARIO("optional values can be created", "[optional unit]") {
       REQUIRE(!opt.has_value());
       REQUIRE_THROWS_AS(opt.value(), dart::bad_optional_access);
       REQUIRE(opt.value_or(-1) == -1);
+      REQUIRE(-1 == opt.value_or(-1));
     }
   }
 
@@ -35,9 +36,13 @@ SCENARIO("optional values can be created", "[optional unit]") {
     THEN("its basic properties make sense") {
       REQUIRE(!!opt);
       REQUIRE(opt == "hello world");
+      REQUIRE("hello world" == opt);
       REQUIRE(*opt == "hello world");
+      REQUIRE("hello world" == *opt);
       REQUIRE(opt.value() == "hello world");
+      REQUIRE("hello world" == opt.value());
       REQUIRE(opt.value_or("nope") == "hello world");
+      REQUIRE("hello world" == opt.value_or("nope"));
     }
   }
 }

--- a/test/type_unit_tests.cc
+++ b/test/type_unit_tests.cc
@@ -656,7 +656,7 @@ SCENARIO("all objects can inject additional keys", "[type unit]") {
 
       // Generate the final object.
       auto pairs = get_arr(keys);
-      auto obj = object {pairs};
+      auto obj = object {packet::make_object(pairs)};
 
       DYNAMIC_WHEN("we inject the orignal key value pairs", idx) {
         auto injected = obj.inject(pairs);


### PR DESCRIPTION
All API types now fully interoperable with:
  * gsl::span
  * std::vector
  * std::array
  * std::deque
  * std::list
  * std::forward_list
  * std::map
  * std::unordered_map
  * std::multimap
  * std::unordered_multimap
  * std::set
  * std::unordered_set
  * std::multiset
  * std::unordered_multiset
  * std::optional
  * std::variant
  * std::tuple
  * std::pair
  * std::chrono::system_clock::time_point