### PR TITLE
fixing an alignment bug in the C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0025 NEW)
 cmake_policy(SET CMP0048 NEW)
 
 # Name the project.
-project(libdart VERSION 1.4.0)
+project(libdart VERSION 1.4.1)
 cmake_minimum_required(VERSION 3.1.0)
 include(CheckIncludeFileCXX)
 

--- a/include/dart.h
+++ b/include/dart.h
@@ -56,7 +56,7 @@ static_assert(false, "libdart requires a c++14 enabled compiler.");
 // Version macros for conditional compilation/feature checks.
 #define DART_MAJOR_VERSION          1
 #define DART_MINOR_VERSION          4
-#define DART_PATCH_VERSION          0
+#define DART_PATCH_VERSION          1
 
 /*----- Type Declarations -----*/
 

--- a/include/dart/abi.h
+++ b/include/dart/abi.h
@@ -33,6 +33,22 @@
 #define DART_ABI_EXPORT
 #endif
 
+// Figure out how to align data on this platform.
+// Hello from 2024, didn't expect to be coming back to this :(
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define DART_ALIGNAS(x) _Alignas(x)
+#elif defined(_MSC_VER)
+#define DART_ALIGNAS(x) __declspec(align(x))
+#elif defined(__GNUC__)
+#define DART_ALIGNAS(x) __attribute__ ((aligned(x)))
+#else
+#error "Dart cannot determine how to align data on this platform."
+#endif
+
+// XXX: Does not protect against double evaluation, watch out
+#define DART_MAX(a, b) ((a) > (b) ? (a) : (b))
+#define DART_MAX_ALIGN DART_MAX(DART_MAX(sizeof(long long), sizeof(double)), sizeof(void*))
+
 #define DART_BUFFER_MAX_SIZE      (1U << 5U)
 #define DART_HEAP_MAX_SIZE        (1U << 6U)
 #define DART_PACKET_MAX_SIZE      DART_HEAP_MAX_SIZE
@@ -217,7 +233,7 @@ extern "C" {
    */
   struct dart_iterator {
     dart_type_id_t rtti;
-    char bytes[DART_ITERATOR_MAX_SIZE];
+    DART_ALIGNAS(DART_MAX_ALIGN) char bytes[DART_ITERATOR_MAX_SIZE];
   };
   typedef struct dart_iterator dart_iterator_t;
 
@@ -240,7 +256,7 @@ extern "C" {
    */
   struct dart_heap {
     dart_type_id_t rtti;
-    char bytes[DART_HEAP_MAX_SIZE];
+    DART_ALIGNAS(DART_MAX_ALIGN) char bytes[DART_HEAP_MAX_SIZE];
   };
   typedef struct dart_heap dart_heap_t;
 
@@ -264,7 +280,7 @@ extern "C" {
    */
   struct dart_buffer {
     dart_type_id_t rtti;
-    char bytes[DART_BUFFER_MAX_SIZE];
+    DART_ALIGNAS(DART_MAX_ALIGN) char bytes[DART_BUFFER_MAX_SIZE];
   };
   typedef struct dart_buffer dart_buffer_t;
 
@@ -287,7 +303,7 @@ extern "C" {
    */
   struct dart_packet {
     dart_type_id_t rtti;
-    char bytes[DART_PACKET_MAX_SIZE];
+    DART_ALIGNAS(DART_MAX_ALIGN) char bytes[DART_PACKET_MAX_SIZE];
   };
   typedef struct dart_packet dart_packet_t;
 
@@ -301,6 +317,8 @@ extern "C" {
     size_t len;
   };
   typedef struct dart_string_view dart_string_view_t;
+
+#undef DART_MAX
 
   /*----- Public Function Declarations -----*/
 


### PR DESCRIPTION
The purpose of this PR is to fix an embarrassing oversight in the C API header. Apparently the C API header never declared proper alignment requirements for the opaque buffers they contain. The C API was added near the end of the project and its testing isn't as comprehensive as the rest of the project. Additionally our usage was usually with heap-backed objects that would've been aligned by the global allocator. For the time being I've updated it to force alignment to whatever is the biggest between `long long`, `double`, and `void*`, hopefully this will suffice.

**Testing Criteria**:
* Hopefully the test harness for this project still works. If so, the PR checks.